### PR TITLE
Correct bookmarked date (#9)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Description of change
+(write a short description or paste a link to JIRA)
+
+# Manual QA steps
+ - 
+ 
+# Risks
+ - 
+ 
+# Rollback steps
+ - revert this branch

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "pendulum",
         "ratelimit",
         "backoff==1.3.2",
-        "requests==2.20.0",
+        "requests==2.20.0", 'pytz'
     ],
     entry_points="""
     [console_scripts]

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -194,15 +194,6 @@ def write_forms_state(atx, form, date_to_resume):
     write_bookmark(atx.state, form, 'date_to_resume', date_to_resume.to_datetime_string())
     atx.write_state()
 
-
-def increment_date(current_date, incremental_range):
-    if incremental_range == "daily":
-        next_date = current_date + datetime.timedelta(days=1, hours=0)
-    elif incremental_range == "hourly":
-        next_date = current_date + datetime.timedelta(days=0, hours=1)
-    return next_date
-
-
 def sync_forms(atx):
     incremental_range = atx.config.get('incremental_range')
 
@@ -256,9 +247,13 @@ def sync_forms(atx):
         # no real reason to assign this other than the naming
         # makes better sense once we go into the loop
         current_date = last_date
-        next_date = increment_date(current_date, incremental_range)
 
-        while next_date <= end_date:
+        while current_date <= end_date:
+            if incremental_range == "daily":
+                next_date = current_date + datetime.timedelta(days=1, hours=0)
+            elif incremental_range == "hourly":
+                next_date = current_date + datetime.timedelta(days=0, hours=1)
+
             ut_current_date = int(current_date.timestamp())
             LOGGER.info('ut_current_date: {} '.format(ut_current_date))
             ut_next_date = int(next_date.timestamp())
@@ -278,7 +273,6 @@ def sync_forms(atx):
             # if the prior sync is successful it will write the date_to_resume bookmark
             write_forms_state(atx, form_id, next_date)
             current_date = next_date
-            next_date = increment_date(current_date, incremental_range)
 
         reset_stream(atx.state, 'questions')
         reset_stream(atx.state, 'landings')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -194,6 +194,15 @@ def write_forms_state(atx, form, date_to_resume):
     write_bookmark(atx.state, form, 'date_to_resume', date_to_resume.to_datetime_string())
     atx.write_state()
 
+
+def increment_date(current_date, incremental_range):
+    if incremental_range == "daily":
+        next_date = current_date + datetime.timedelta(days=1, hours=0)
+    elif incremental_range == "hourly":
+        next_date = current_date + datetime.timedelta(days=0, hours=1)
+    return next_date
+
+
 def sync_forms(atx):
     incremental_range = atx.config.get('incremental_range')
 
@@ -247,13 +256,9 @@ def sync_forms(atx):
         # no real reason to assign this other than the naming
         # makes better sense once we go into the loop
         current_date = last_date
+        next_date = increment_date(current_date, incremental_range)
 
-        while current_date <= end_date:
-            if incremental_range == "daily":
-                next_date = current_date + datetime.timedelta(days=1, hours=0)
-            elif incremental_range == "hourly":
-                next_date = current_date + datetime.timedelta(days=0, hours=1)
-
+        while next_date <= end_date:
             ut_current_date = int(current_date.timestamp())
             LOGGER.info('ut_current_date: {} '.format(ut_current_date))
             ut_next_date = int(next_date.timestamp())
@@ -273,6 +278,7 @@ def sync_forms(atx):
             # if the prior sync is successful it will write the date_to_resume bookmark
             write_forms_state(atx, form_id, next_date)
             current_date = next_date
+            next_date = increment_date(current_date, incremental_range)
 
         reset_stream(atx.state, 'questions')
         reset_stream(atx.state, 'landings')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -271,7 +271,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, next_date)
+            write_forms_state(atx, form_id, min(datetime.datetime.utcnow(), next_date))
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,0 +1,63 @@
+import datetime
+import pytz
+import unittest
+from unittest.mock import patch
+
+from tap_typeform.context import Context
+from tap_typeform.streams import sync_forms
+
+
+class TestStreams(unittest.TestCase):
+    def setUp(self):
+        self.form_id = "test_form_id"
+        self.config = {
+            "forms": self.form_id,
+            "incremental_range": "hourly",
+            "start_date": "2019-11-02 10:00:00",
+            "end_date": "2019-11-02 12:00:00",
+            "token": "token",
+        }
+        self.state = {"bookmark": {"form_id": self.form_id}}
+
+        self.atx = Context(self.config, self.state)
+        self.atx.selected_stream_ids = ["answers"]
+
+    @patch("tap_typeform.streams.sync_form")
+    def test_sync_form(self, mock_sync_form):
+        mock_sync_form.return_value = [10, ""]  # To prevent Value Error
+
+        sync_forms(self.atx)
+
+        self.assertEqual(mock_sync_form.call_count, 2)
+
+    @patch("tap_typeform.streams.sync_form")
+    def test_bookmarked_date_is_correct(self, mock_sync_form):
+        mock_sync_form.return_value = [10, ""]  # To prevent Value Error
+        end_date = pytz.utc.localize(
+            datetime.datetime.strptime(self.config.get("end_date"), "%Y-%m-%d %H:%M:%S")
+        )
+
+        sync_forms(self.atx)
+
+        date_to_resume = self.atx.state.get("bookmarks").get(self.form_id, {}).get("date_to_resume")
+        expected_date_to_resume = end_date.strftime("%Y-%m-%d %H:%M:%S")
+
+        assert date_to_resume == expected_date_to_resume
+
+    @patch("tap_typeform.streams.sync_form")
+    def test_when_end_date_is_not_round(self, mock_sync_form):
+        self.config["end_date"] = "2019-11-02 11:30:00"
+        self.atx = Context(self.config, self.state)
+        self.atx.selected_stream_ids = ["answers"]
+        mock_sync_form.return_value = [10, ""]  # To prevent Value Error
+
+        sync_forms(self.atx)
+
+        date_to_resume = self.atx.state.get("bookmarks").get(self.form_id, {}).get("date_to_resume")
+        expected_date_to_resume = "2019-11-02 11:00:00"  # Or is it 11:30:00 ?
+
+        assert date_to_resume == expected_date_to_resume
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Misbehavior**
Say I set `incremental_range = 'daily'`. 
If the tap is run at 8:AM, all the answers and landings between midnight and 8:AM will be retrieved.
An attempt to get data after 8:AM will be made with obviously no returned data. 

The next job will have its `date_to_resume` set to the next day at midnight. So the next jobs won't retrieve the data after 8:AM.
The resulting problem can be seen in #9 .

This PR aims at preventing `date_to_resume` to be higher than `end_date`.
