### PR TITLE
Fix bookmarking

### DIFF
--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -230,10 +230,10 @@ def sync_forms(atx):
         # if end date is now, we will have to truncate them
         # to the nearest day/hour before we can use it.
         if incremental_range == "daily":
-            e_d = now.replace(hour=0, minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
+            e_d = now.replace(hour=0, minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S") + datetime.timedelta(days=1, hours=0)
             end_date = pendulum.parse(atx.config.get('end_date', e_d))
         elif incremental_range == "hourly":
-            e_d = now.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
+            e_d = now.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S") + datetime.timedelta(days=0, hours=1)
             end_date = pendulum.parse(atx.config.get('end_date', e_d))
         LOGGER.info('end_date: {} '.format(end_date))
 
@@ -270,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, current_date)
+            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at) + datetime.timedelta(seconds=1))
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -270,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at))
+            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at) if max_submitted_at else next_date)
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -270,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at).date() if max_submitted_at else next_date)
+            write_forms_state(atx, form_id, current_date)
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -270,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, current_date)
+            write_forms_state(atx, form_id, max(current_date, pendulum.parse(max_submitted_at)))
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -271,7 +271,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, next_date)
+            write_forms_state(atx, form_id, min(max_submitted_at, next_date))
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -271,7 +271,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, min(max_submitted_at, next_date))
+            write_forms_state(atx, form_id, max_submitted_at)
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -230,10 +230,10 @@ def sync_forms(atx):
         # if end date is now, we will have to truncate them
         # to the nearest day/hour before we can use it.
         if incremental_range == "daily":
-            e_d = now.replace(hour=0, minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S") + datetime.timedelta(days=1, hours=0)
+            e_d = (now.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=1, hours=0)).strftime("%Y-%m-%d %H:%M:%S")
             end_date = pendulum.parse(atx.config.get('end_date', e_d))
         elif incremental_range == "hourly":
-            e_d = now.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S") + datetime.timedelta(days=0, hours=1)
+            e_d = (now.replace(minute=0, second=0, microsecond=0) + datetime.timedelta(days=0, hours=1)).strftime("%Y-%m-%d %H:%M:%S")
             end_date = pendulum.parse(atx.config.get('end_date', e_d))
         LOGGER.info('end_date: {} '.format(end_date))
 

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -243,7 +243,6 @@ def sync_forms(atx):
         last_date = pendulum.parse(bookmark.get('date_to_resume', s_d))
         LOGGER.info('last_date: {} '.format(last_date))
 
-
         # no real reason to assign this other than the naming
         # makes better sense once we go into the loop
         current_date = last_date
@@ -271,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, max_submitted_at)
+            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at))
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -270,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at) if max_submitted_at else next_date)
+            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at).date() if max_submitted_at else next_date)
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -270,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at) + datetime.timedelta(seconds=1))
+            write_forms_state(atx, form_id, pendulum.parse(max_submitted_at))
             current_date = next_date
 
         reset_stream(atx.state, 'questions')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -270,7 +270,7 @@ def sync_forms(atx):
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, max(current_date, pendulum.parse(max_submitted_at)))
+            write_forms_state(atx, form_id, current_date)
             current_date = next_date
 
         reset_stream(atx.state, 'questions')


### PR DESCRIPTION
# Description of change

Updated the bookmarked date for TypeForm so that recent responses are captured without requiring a full resync.

Also made an update so that the default end date will not be in the past.

# Manual QA steps
 
First, I ran the existing tap:

```
$ pip install tap-typeform

$ pip install https://github.com/chrisgoddard/singer-discover/archive/master.zip

$ cat config.json

{
  "token": "<redacted>",
  "start_date": "2019-12-05T00:00:00Z",
  "forms": "ZjsA3Q",
  "incremental_range": "daily"
}

$ tap-typeform --config config.json --discover | singer-discover -o catalog.json

$ tap-typeform --config config.json --properties catalog.json

INFO --------------------
INFO landings: 1
INFO answers: 12
INFO questions: 15
INFO --------------------
```

I saved the output `STATE` message:

```
$ echo '{"bookmarks": {"ZjsA3Q": {"date_to_resume": "2019-12-13 00:00:00"}}}' > state.json
```

Then, I submitted a new form response on 12/12 at 18:35 UTC and tried to pick-up where I left off based on that `state.json` and no results were returned.

```
$ tap-typeform --config config.json --properties catalog.json --state state.json

INFO --------------------
INFO landings: 0
INFO answers: 0
INFO questions: 15
INFO --------------------
```

Now, trying with this fork:

```
$ pip install https://github.com/kingfink/tap-typeform/archive/master.zip

$ tap-typeform --config config.json --properties catalog.json

INFO --------------------
INFO landings: 2
INFO answers: 25
INFO questions: 15
INFO --------------------
```

I saved the output of the new `STATE` message and then submitted another new response on 12/12.

```
$ echo '{"bookmarks": {"ZjsA3Q": {"date_to_resume": "2019-12-12 00:00:00"}}}' > state.json
```

Running again and successfully getting the new response:

```
$ tap-typeform --config config.json --properties catalog.json --state state.json

INFO --------------------
INFO landings: 3
INFO answers: 37
INFO questions: 15
INFO --------------------
```
Finally, testing along with `target-csv` and verifying the files generated(`answers-*.csv`, `landings-*.csv`, `questions-*.csv`) contained the correct information.

```
$ tap-typeform --config config.json --properties catalog.json --state state.json | target-csv
```
 
# Risks
 - ?
 
# Rollback steps
 - revert this branch
