### PR TITLE
Bump to v1.1.3, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.3
+  * Fix bookmarking to use the max `submitted_at` value instead of the end
+    of our query's date window [#16](https://github.com/singer-io/tap-typeform/pull/16)
+
 ## 1.1.2
   * Use `dict.get()` to access more fields rather than `[]` [#3](https://github.com/singer-io/tap-typeform/pull/5)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="1.1.2",
+    version="1.1.3",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
Version bump for #16 

# Manual QA steps
 - See #16 
 
# Risks
 - It's possible we are still bookmarking on the wrong value
 
# Rollback steps
 - revert #16 and bump the version
