### PR TITLE
Handle empty forms

### DIFF
--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -96,7 +96,7 @@ def sync_form_definition(atx, form_id):
                 raise Exception('Metric job timeout ({} secs)'.format(
                     MAX_METRIC_JOB_TIME))
             response = get_form_definition(atx, form_id)
-            data = response['fields']
+            data = response.get('fields',[])
             if data != '':
                 break
             else:

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -162,7 +162,7 @@ def sync_form(atx, form_id, start_date, end_date):
 
         max_submitted_dt = row['submitted_at']
 
-        if ('answers' in row) and 'answers' in atx.selected_stream_ids:
+        if row.get('answers') and 'answers' in atx.selected_stream_ids:
             for answer in row['answers']:
                 data_type = answer.get('type')
 


### PR DESCRIPTION
If a form is empty, this line will raise an exception. 
The problem is that this exception will fail the extraction for all the (non-empty) forms, and so break the replication.

# Description of change
Handle empty forms

# Manual QA steps
 - Create a form, without any question. 
- Set its ID in config.json. 
- run replication
 
# Risks
 - None ?
 
# Rollback steps
 - revert this branch
