### PR TITLE
Add exception handling tests

### DIFF
--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -44,7 +44,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     403: {
         "raise_exception": TypeformForbiddenError,
-        "message": "User doesn't have permission to access the resource."
+        "message": "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
     },
     404: {
         "raise_exception": TypeformNotFoundError,

--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -164,7 +164,8 @@ def raise_for_error(response):
 
             exc = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("raise_exception", TypeformError)
             message = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("message", "")
-            raise exc(message, response) from None
+            formatted_message = f"HTTP-error-code: {error_code}, Error: {message}"
+            raise exc(formatted_message, response) from None
 
         except (ValueError, TypeError):
             raise TypeformError(error) from None

--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -44,7 +44,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     403: {
         "raise_exception": TypeformForbiddenError,
-        "message": "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
+        "message": "User doesn't have permission to access the resource."
     },
     404: {
         "raise_exception": TypeformNotFoundError,
@@ -83,7 +83,7 @@ class Client(object):
                           TypeformTooManyError,
                           max_tries=3,
                           factor=2)
-    def request(self, method, url, **kwargs):
+    def request(self, method, url, params=None, **kwargs):
         # note that typeform response api doesn't return limit headers
 
         if 'headers' not in kwargs:
@@ -91,7 +91,9 @@ class Client(object):
         if self.token:
             kwargs['headers']['Authorization'] = self.token
 
-        response = requests.request(method, url, **kwargs)
+        request = requests.Request(method, url, headers=kwargs['headers'], params=params)
+
+        response = self.session.send(request.prepare())
 
         if response.status_code != 200:
             raise_for_error(response)

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -313,6 +313,6 @@ def sync_forms(atx):
     if 'forms'in atx.selected_stream_ids:
         state = sync_latest_forms(atx)
 
-    singer.write_state(state)
+        singer.write_state(state)
 
-    reset_stream(atx.state, 'forms')
+        reset_stream(atx.state, 'forms')

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -5,10 +5,8 @@ import json
 import pendulum
 import singer
 from singer.bookmarks import write_bookmark, reset_stream
-from ratelimit import limits, sleep_and_retry, RateLimitException
 from backoff import on_exception, expo, constant
 
-from .http import MetricsRateLimitException
 
 LOGGER = singer.get_logger()
 
@@ -66,17 +64,9 @@ def select_fields(mdata, obj):
             new_obj[key] = value
     return new_obj
 
-@on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
-@on_exception(expo, RateLimitException, max_tries=5)
-@sleep_and_retry
-@limits(calls=1, period=6) # 5 seconds needed to be padded by 1 second to work
 def get_form_definition(atx, form_id):
     return atx.client.get_form_definition(form_id)
 
-@on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
-@on_exception(expo, RateLimitException, max_tries=5)
-@sleep_and_retry
-@limits(calls=1, period=6) # 5 seconds needed to be padded by 1 second to work
 def get_form(atx, form_id, start_date, end_date):
     LOGGER.info('Forms query - form: {} start_date: {} end_date: {} '.format(
         form_id,
@@ -88,10 +78,6 @@ def get_form(atx, form_id, start_date, end_date):
     # to take the last submitted_at date and use it to cycle through
     return atx.client.get_form_responses(form_id, params={'since': start_date, 'until': end_date, 'page_size': 1000})
 
-@on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
-@on_exception(expo, RateLimitException, max_tries=5)
-@sleep_and_retry
-@limits(calls=1, period=6) # 5 seconds needed to be padded by 1 second to work
 def get_forms(atx):
     LOGGER.info('All forms query')
     return atx.client.get_forms()

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -181,7 +181,7 @@ class TestClientExceptionHandling(unittest.TestCase):
 
 
     @mock.patch('requests.request', side_effect=mocked_failed_429_request)
-    def test_too_many_requests_429_not_backoff_behavior(self, mocked_session, mocked_failed_429_request):
+    def test_too_many_requests_429_backoff_behavior(self, mocked_session, mocked_failed_429_request):
         config = {'token': '123'}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,699 @@
+import tap_typeform.http as client
+import unittest
+import requests
+from unittest import mock
+import json
+
+
+def mocked_session(*args, **kwargs):
+    class Mocksession:
+        def __init__(self, json_data, status_code, content, headers, raise_error):
+            self.text = json_data
+            self.status_code = status_code
+            self.raise_error = raise_error
+            if headers:
+                self.headers = headers
+
+        def raise_for_status(self):
+            if not self.raise_error:
+                return self.status_code
+
+            raise requests.HTTPError("sample message")
+
+        def json(self):
+            return self.text
+
+    arguments_to_session = args[0]
+
+    json_data = arguments_to_session[0]
+    status_code = arguments_to_session[1]
+    content = arguments_to_session[2]
+    headers = arguments_to_session[3]
+    raise_error = arguments_to_session[4]
+    return Mocksession(json_data, status_code, content, headers, raise_error)
+
+
+class Mockresponse:
+    def __init__(self, resp, status_code, content=[], headers=None, raise_error=False):
+        self.json_data = resp
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+        self.raise_error = raise_error
+
+    def prepare(self):
+        return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("sample message")
+
+
+def mocked_forbidden_403_exception(*args, **kwargs):
+    json_decode_str = {"Title": "Forbidden", "Detail": "AuthenticationUnsuccessful"}
+
+    return Mockresponse(json_decode_str, 403, raise_error=True)
+
+
+def mocked_badrequest_400_error(*args, **kwargs):
+    json_decode_str = {"Message": "Bad Request Error"}
+
+    return Mockresponse(json_decode_str, 400, raise_error=True)
+
+
+def mocked_unauthorized_401_error(*args, **kwargs):
+    json_decode_str = {"Title": "Unauthorized", "Detail": "AuthenticationUnsuccessful"}
+
+    return Mockresponse(json_decode_str, 401, raise_error=True)
+
+
+def mocked_notfound_404_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 404, raise_error=True)
+
+
+def mocked_precondition_failed_412_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 412, raise_error=True)
+
+
+def mocked_failed_429_request_in_day(*args, **kwargs):
+    json_decode_str = ''
+    headers = {"Retry-After": 1000, "X-Rate-Limit-Problem": "day"}
+    return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
+
+
+def mocked_failed_429_request_in_minute(*args, **kwargs):
+    json_decode_str = ''
+    headers = {"Retry-After": 5, "X-Rate-Limit-Problem": "minute"}
+    return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
+
+
+def mocked_internalservererror_500_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 500, raise_error=True)
+
+
+def mocked_notimplemented_501_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 501, raise_error=True)
+
+
+def mocked_not_available_503_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 503, raise_error=True)
+
+
+def mock_successful_request(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 200)
+
+
+def mock_successful_session_post(*args, **kwargs):
+    json_decode_str = {"access_token": "123", "refresh_token": "345"}
+
+    return mocked_session((json_decode_str, 200, [], None, False))
+
+
+def mocked_jsondecode_failing_request(*args, **kwargs):
+    # Invalid json string
+    json_decode_error_str = '{\'Contacts\': \'value\'}'
+    return Mockresponse(json_decode_error_str, 200)
+
+
+def mocked_jsondecode_successful_request(*args, **kwargs):
+    # Valid json string
+    json_decode_str = '{"Contacts": "value"}'
+    return Mockresponse(json_decode_str, 200)
+
+
+@mock.patch('requests.Session.send', side_effect=mocked_session)
+class TestFilterFunExceptionHandling(unittest.TestCase):
+    """
+    Test cases to verify if the exceptions are handled as expected while communicating with Xero Environment 
+    """
+
+    @mock.patch('requests.Request', side_effect=mocked_jsondecode_failing_request)
+    def test_json_decode_exception(self, mocked_session, mocked_jsondecode_failing_request):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except json.decoder.JSONDecodeError as e:
+            pass
+
+        self.assertEqual(mocked_jsondecode_failing_request.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+
+    @mock.patch('requests.Request', side_effect=mocked_jsondecode_successful_request)
+    def test_normal_filter_execution(self, mocked_session, mocked_jsondecode_successful_request):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except json.decoder.JSONDecodeError as e:
+            pass
+
+        self.assertEqual(mocked_jsondecode_successful_request.call_count, 1)
+        self.assertEqual(mocked_session.call_count, 1)
+
+
+    @mock.patch('requests.Request', side_effect=mocked_badrequest_400_error)
+    def test_badrequest_400_error(self, mocked_session, mocked_badrequest_400_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroBadRequestError as e:
+            expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_unauthorized_401_error)
+    def test_unauthorized_401_error(self, mocked_session, mocked_unauthorized_401_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroUnauthorizedError as e:
+            expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_forbidden_403_exception)
+    def test_forbidden_403_exception(self, mocked_session, mocked_forbidden_403_exception):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroForbiddenError as e:
+            expected_error_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_notfound_404_error)
+    def test_notfound_404_error(self, mocked_session, mocked_notfound_404_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroNotFoundError as e:
+            expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+    @mock.patch('requests.Request', side_effect=mocked_precondition_failed_412_error)
+    def test_precondition_failed_412_error(self, mocked_session, mocked_precondition_failed_412_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroPreConditionFailedError as e:
+            expected_error_message = "HTTP-error-code: 412, Error: One or more conditions given in the request header fields were invalid."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    def test_internalservererror_500_error(self, mocked_session, mocked_internalservererror_500_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroInternalError as e:
+            expected_error_message = "HTTP-error-code: 500, Error: An unhandled error with the Xero API. Contact the Xero API team if problems persist."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_notimplemented_501_error)
+    def test_notimplemented_501_error(self, mocked_session, mocked_notimplemented_501_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroNotImplementedError as e:
+            expected_error_message = "HTTP-error-code: 501, Error: The method you have called has not been implemented."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+    @mock.patch('requests.Request', side_effect=mocked_not_available_503_error)
+    def test_not_available_503_error(self, mocked_session, mocked_not_available_503_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.filter(tap_stream_id)
+        except client_.XeroNotAvailableError as e:
+            expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_day)
+    def test_too_many_requests_429_in_day_error(self, mocked_session, mocked_failed_429_request_in_day):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            # Verifying if the custom exception 'XeroTooManyError' is raised on receiving status code 429 with daily limit exceeded
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except client_.XeroTooManyError as e:
+            expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 1000 seconds"
+            
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_minute)
+    def test_too_many_requests_429_in_minute_error(self, mocked_session, mocked_failed_429_request_in_minute):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            # Verifying if the custom exception 'XeroTooManyInMinuteError' is raised on receiving status code 429 with minute limit exceeded
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except client_.XeroTooManyInMinuteError as e:
+            expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 5 seconds"
+            
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_day)
+    def test_too_many_requests_in_day_429_not_backoff_behavior(self, mocked_session, mocked_failed_429_request_in_day):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except (requests.HTTPError, client_.XeroTooManyError) as e:
+            pass
+
+        #Verify daily limit should not backoff
+        self.assertEqual(mocked_failed_429_request_in_day.call_count, 1)
+        self.assertEqual(mocked_session.call_count, 1)
+
+
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_minute)
+    def test_too_many_requests_in_minute_429_backoff_behavior(self, mocked_session, mocked_failed_429_request_in_minute):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except (requests.HTTPError, client_.XeroTooManyInMinuteError) as e:
+            pass
+
+        self.assertEqual(mocked_failed_429_request_in_minute.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    def test_internalservererror_500_backoff_behaviour(self, mocked_session, mocked_internalservererror_500_error):
+        config = {}
+        tap_stream_id = "contacts"
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+        try:
+            filter_func_exec = xero_client.filter(tap_stream_id)
+        except (requests.HTTPError, client_.XeroInternalError) as e:
+            pass
+
+        self.assertEqual(mocked_internalservererror_500_error.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+
+
+@mock.patch('requests.Session.send', side_effect=mocked_session)
+class TestCheckPlatformAccessBehavior(unittest.TestCase):
+
+    @mock.patch('requests.Session.post', side_effect=mocked_unauthorized_401_error)
+    def test_check_unauthorized_401_error_in_discovery_mode(self, mocked_unauthorized_401_error, mocked_session):
+        config = {
+            "client_id": "123",
+            "client_secret": "123",
+            "refresh_token": "123",
+            "tenant_id": "123"
+        }
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroUnauthorizedError as e:
+            expected_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+            self.assertEqual(str(e) ,expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_forbidden_403_exception)
+    def test_check_forbidden_403_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_forbidden_403_exception):
+
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroForbiddenError as e:
+            expected_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
+            self.assertEqual(str(e) ,expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_badrequest_400_error)
+    def test_badrequest_400_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_badrequest_400_error):
+        
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroBadRequestError as e:
+            expected_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_notfound_404_error)
+    def test_notfound_404_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_notfound_404_error):
+
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroNotFoundError as e:
+            expected_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_precondition_failed_412_error)
+    def test_precondition_failed_412_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_precondition_failed_412_error):
+        
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroPreConditionFailedError as e:
+            expected_message = "HTTP-error-code: 412, Error: One or more conditions given in the request header fields were invalid."
+            self.assertEqual(str(e), expected_message)
+        
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    def test_internalservererror_500_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_internalservererror_500_error):
+
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroInternalError as e:
+            expected_message = "HTTP-error-code: 500, Error: An unhandled error with the Xero API. Contact the Xero API team if problems persist."
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_notimplemented_501_error)
+    def test_notimplemented_501_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_notimplemented_501_error):
+
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroNotImplementedError as e:
+            expected_message = "HTTP-error-code: 501, Error: The method you have called has not been implemented."
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_not_available_503_error)
+    def test_not_available_503_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_not_available_503_error):
+        
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroNotAvailableError as e:
+            expected_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_day)
+    def test_too_many_requests_in_day_429_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_failed_429_request_in_day):
+        
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroTooManyError as e:
+            expected_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 1000 seconds"
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_minute)
+    def test_too_many_requests_in_minute_429_error_in_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_failed_429_request_in_minute):
+
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except client_.XeroTooManyInMinuteError as e:
+            expected_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded. Please retry after 5 seconds"
+            self.assertEqual(str(e), expected_message)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_day)
+    def test_too_many_requests_in_day_429_not_backoff_behavior_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_failed_429_request_in_day):
+
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except (requests.HTTPError, client_.XeroTooManyError) as e:
+            pass
+
+        #Verify daily limit should not backoff
+        self.assertEqual(mocked_failed_429_request_in_day.call_count, 1)
+        self.assertEqual(mocked_session.call_count, 1)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_minute)
+    def test_too_many_requests_in_minute_429_backoff_behavior_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_failed_429_request_in_minute):
+
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except (requests.HTTPError, client_.XeroTooManyInMinuteError) as e:
+            pass
+
+        self.assertEqual(mocked_failed_429_request_in_minute.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+
+    @mock.patch("tap_xero.client.XeroClient.refresh_credentials")
+    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    def test_internalservererror_500_backoff_behaviour_discovery_mode(self, mocked_refresh_credentials, mocked_session, mocked_internalservererror_500_error):
+        
+        mocked_refresh_credentials.return_value = ""
+        config = {}
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        xero_client.access_token = "123"
+        xero_client.tenant_id = "123"
+
+        try:
+            xero_client.check_platform_access(config, config_path)
+        except (requests.HTTPError, client_.XeroInternalError) as e:
+            pass
+
+        self.assertEqual(mocked_internalservererror_500_error.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+
+    @mock.patch('requests.Session.post', side_effect=mock_successful_session_post)
+    @mock.patch('tap_xero.client.update_config_file')
+    @mock.patch('requests.Request', side_effect=mock_successful_request)
+    def test_check_success_200_in_discovery_mode(self, mock_successful_session_post, mocked_update_config_file, mocked_session, mock_successful_request):
+
+        mocked_update_config_file.return_value = ""
+
+        config = {
+            "client_id": "123",
+            "client_secret": "123",
+            "refresh_token": "123",
+            "tenant_id": "123"
+        }
+        config_path = ""
+
+        xero_client = client_.XeroClient(config)
+        expected_access_token = "123"
+        expected_refresh_token = "345"
+
+        xero_client.check_platform_access(config, config_path)
+
+        self.assertEqual(xero_client.access_token, expected_access_token)
+        self.assertEqual(config["refresh_token"], expected_refresh_token)
+        self.assertEqual(xero_client.tenant_id, config["tenant_id"])

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -45,7 +45,7 @@ def mocked_notfound_404_error(*args, **kwargs):
     return Mockresponse(json_decode_str, 404, raise_error=True)
 
 
-def mocked_failed_429_request_in_day(*args, **kwargs):
+def mocked_failed_429_request(*args, **kwargs):
     json_decode_str = ''
     headers = {"Retry-After": 1000, "X-Rate-Limit-Problem": "day"}
     return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
@@ -93,14 +93,14 @@ def mocked_jsondecode_successful_request(*args, **kwargs):
     return Mockresponse(json_decode_str, 200)
 
 
-@mock.patch('requests.Request', side_effect=Mockresponse)
+@mock.patch('requests.request', side_effect=Mockresponse)
 class TestClientExceptionHandling(unittest.TestCase):
     """
     Test cases to verify if the exceptions are handled as expected while communicating with Xero Environment 
     """
     endpoint = "forms"
 
-    @mock.patch('requests.Request', side_effect=mocked_badrequest_400_error)
+    @mock.patch('requests.request', side_effect=mocked_badrequest_400_error)
     def test_badrequest_400_error(self, mocked_session, mocked_badrequest_400_error):
         config = {'token': '123'}
         client = client_.Client(config)
@@ -115,7 +115,7 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
 
-    @mock.patch('requests.Request', side_effect=mocked_unauthorized_401_error)
+    @mock.patch('requests.request', side_effect=mocked_unauthorized_401_error)
     def test_unauthorized_401_error(self, mocked_session, mocked_unauthorized_401_error):
         config = {'token': '123'}
         client = client_.Client(config)
@@ -130,7 +130,7 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
 
-    @mock.patch('requests.Request', side_effect=mocked_forbidden_403_exception)
+    @mock.patch('requests.request', side_effect=mocked_forbidden_403_exception)
     def test_forbidden_403_exception(self, mocked_session, mocked_forbidden_403_exception):
         config = {'token': '123'}
         client = client_.Client(config)
@@ -145,7 +145,7 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
 
-    @mock.patch('requests.Request', side_effect=mocked_notfound_404_error)
+    @mock.patch('requests.request', side_effect=mocked_notfound_404_error)
     def test_notfound_404_error(self, mocked_session, mocked_notfound_404_error):
         config = {'token': '123'}
         client = client_.Client(config)
@@ -160,7 +160,7 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
 
-    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    @mock.patch('requests.request', side_effect=mocked_internalservererror_500_error)
     def test_internalservererror_500_error(self, mocked_session, mocked_internalservererror_500_error):
         config = {'token': '123'}
         client = client_.Client(config)
@@ -175,7 +175,7 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
 
-    @mock.patch('requests.Request', side_effect=mocked_not_available_503_error)
+    @mock.patch('requests.request', side_effect=mocked_not_available_503_error)
     def test_not_available_503_error(self, mocked_session, mocked_not_available_503_error):
         config = {'token': '123'}
         client = client_.Client(config)
@@ -190,8 +190,8 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
 
-    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_day)
-    def test_too_many_requests_429_in_day_error(self, mocked_session, mocked_failed_429_request_in_day):
+    @mock.patch('requests.request', side_effect=mocked_failed_429_request)
+    def test_too_many_requests_429(self, mocked_session, mocked_failed_429_request):
         config = {'token': '123'}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
@@ -205,8 +205,8 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
 
-    @mock.patch('requests.Request', side_effect=mocked_failed_429_request_in_day)
-    def test_too_many_requests_in_day_429_not_backoff_behavior(self, mocked_session, mocked_failed_429_request_in_day):
+    @mock.patch('requests.request', side_effect=mocked_failed_429_request)
+    def test_too_many_requests_429_not_backoff_behavior(self, mocked_session, mocked_failed_429_request):
         config = {'token': '123'}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
@@ -216,11 +216,11 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
         #Verify daily limit should not backoff
-        self.assertEqual(mocked_failed_429_request_in_day.call_count, 1)
+        self.assertEqual(mocked_failed_429_request.call_count, 1)
         self.assertEqual(mocked_session.call_count, 1)
 
 
-    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    @mock.patch('requests.request', side_effect=mocked_internalservererror_500_error)
     def test_internalservererror_500_backoff_behaviour(self, mocked_session, mocked_internalservererror_500_error):
         config = {'token': '123'}
         client = client_.Client(config)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 from unittest import mock
 
@@ -51,12 +50,6 @@ def mocked_failed_429_request(*args, **kwargs):
     return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
 
 
-def mocked_failed_429_request_in_minute(*args, **kwargs):
-    json_decode_str = ''
-    headers = {"Retry-After": 5, "X-Rate-Limit-Problem": "minute"}
-    return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
-
-
 def mocked_internalservererror_500_error(*args, **kwargs):
     json_decode_str = {}
 
@@ -73,24 +66,6 @@ def mocked_not_available_503_error(*args, **kwargs):
     json_decode_str = {}
 
     return Mockresponse(json_decode_str, 503, raise_error=True)
-
-
-def mock_successful_request(*args, **kwargs):
-    json_decode_str = {}
-
-    return Mockresponse(json_decode_str, 200)
-
-
-def mocked_jsondecode_failing_request(*args, **kwargs):
-    # Invalid json string
-    json_decode_error_str = '{\'Contacts\': \'value\'}'
-    return Mockresponse(json_decode_error_str, 200)
-
-
-def mocked_jsondecode_successful_request(*args, **kwargs):
-    # Valid json string
-    json_decode_str = '{"Contacts": "value"}'
-    return Mockresponse(json_decode_str, 200)
 
 
 @mock.patch('requests.request', side_effect=Mockresponse)
@@ -216,8 +191,7 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
         #Verify daily limit should not backoff
-        self.assertEqual(mocked_failed_429_request.call_count, 1)
-        self.assertEqual(mocked_session.call_count, 1)
+        self.assertEqual(mocked_failed_429_request.call_count, 3)
 
 
     @mock.patch('requests.request', side_effect=mocked_internalservererror_500_error)
@@ -231,7 +205,6 @@ class TestClientExceptionHandling(unittest.TestCase):
             pass
 
         self.assertEqual(mocked_internalservererror_500_error.call_count, 3)
-        self.assertEqual(mocked_session.call_count, 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description of change
Implemented changes as requested in [TDL-12608](https://jira.talendforge.org/browse/TDL-12608). Refactored API error handling. Removed duplicate backoff calls from individual function calls and kept backoff decorator only where API request is made. Added tests to test the API's exception handling.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
