### PR TITLE
Fix bookmarks test

### DIFF
--- a/tests/test_typeform_bookmarks.py
+++ b/tests/test_typeform_bookmarks.py
@@ -118,7 +118,6 @@ class TypeformBookmarks(TypeformBaseTest):
         ### Second Sync
         ##########################################################################
         self.start_date = self.start_date_2
-        conn_id = connections.ensure_connection(self, original_properties=False)
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)


### PR DESCRIPTION
# Description of change
This PR removes the second call to `ensure_connection()` because that will delete the old connection we just inserted the simulated state for.

# Manual QA steps
 - None
 
# Risks
 - Low, it's just a test change
 
# Rollback steps
 - revert this branch
