### PR TITLE
Bump to v1.3.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.0
+  * Add the Forms stream [#29](https://github.com/singer-io/tap-typeform/pull/29)
+  * Add integration tests [#32](https://github.com/singer-io/tap-typeform/pull/32)
+  * Add unit test for exception handling [#33](https://github.com/singer-io/tap-typeform/pull/33)
+  * Add config validation to ensure only valid forms are input by the user [#34](https://github.com/singer-io/tap-typeform/pull/34)
+  * Fix a bug in the bookmarks test [#36](https://github.com/singer-io/tap-typeform/pull/36)
+
 ## 1.2.0
   * Add logic to handle empty forms
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="1.2.0",
+    version="1.3.0",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
Bump to v1.3.0, update changelog

## 1.3.0
  * Add the Forms stream [#29](https://github.com/singer-io/tap-typeform/pull/29)
  * Add integration tests [#32](https://github.com/singer-io/tap-typeform/pull/32)
  * Add unit test for exception handling [#33](https://github.com/singer-io/tap-typeform/pull/33)
  * Add config validation to ensure only valid forms are input by the user [#34](https://github.com/singer-io/tap-typeform/pull/34)
  * Fix a bug in the bookmarks test [#36](https://github.com/singer-io/tap-typeform/pull/36)

# Manual QA steps
See the following PRs
- #29
- #32
- #33
- #34
- #36
 
# Risks
See the following PRs
- #29
- #32
- #33
- #34
- #36
 
# Rollback steps
 - revert the code and bump the version
