### PR TITLE
Revert revert and log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - add_ssh_keys
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            python3 -mvenv /usr/local/share/virtualenvs/tap-typeform
+            source /usr/local/share/virtualenvs/tap-typeform/bin/activate
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install .[dev]
+      - run:
+          when: always
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            pip install nose
+            nosetests tests/unittests
+      - run:
+          name: 'Integration Tests'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-typeform \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     --token=$STITCH_API_TOKEN \
+                     tests
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: circleci-user

--- a/.gitignore
+++ b/.gitignore
@@ -94,11 +94,11 @@ ENV/
 
 # Custom stuff
 env.sh
-config.json
+*config.json
 .autoenv.zsh
 
 rsa-key
 tags
 singer-check-tap-data
-state.json
-catalog.json
+state*.json
+catalog*.json

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,19 @@ setup(
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     install_requires=[
-        "singer-python==5.4.0",
+        "singer-python==5.10.0",
         "pendulum",
         "ratelimit",
-        "backoff==1.3.2",
-        "requests==2.20.0",
+        "backoff",
+        "requests",
     ],
+    extras_require={
+        'dev': [
+            'pylint',
+            'ipdb',
+            'nose',
+        ]
+    },
     entry_points="""
     [console_scripts]
     tap-typeform=tap_typeform:main

--- a/tap_typeform/__init__.py
+++ b/tap_typeform/__init__.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
-
-import os
-import sys
-import json
-
 import singer
 from singer import utils
-from singer.catalog import Catalog, CatalogEntry, Schema
-from . import streams
-from .context import Context
-from . import schemas
+from singer.catalog import Catalog, metadata_module as metadata
+from tap_typeform import streams
+from tap_typeform.context import Context
+from tap_typeform.http import Client
+from tap_typeform import schemas
 
 REQUIRED_CONFIG_KEYS = ["token", "forms", "incremental_range"]
 
@@ -17,6 +13,11 @@ LOGGER = singer.get_logger()
 
 #def check_authorization(atx):
 #    atx.client.get('/settings')
+class FormMistmatchError(Exception):
+    pass
+
+class NoFormsProvidedError(Exception):
+    pass
 
 
 # Some taps do discovery dynamically where the catalog is read in from a
@@ -25,31 +26,35 @@ LOGGER = singer.get_logger()
 #  atx in here since the schema is from file but we would use it if we
 #  pulled schema from the API def discover(atx):
 def discover():
-    catalog = Catalog([])
+    streams = []
     for tap_stream_id in schemas.STATIC_SCHEMA_STREAM_IDS:
         #print("tap stream id=",tap_stream_id)
-        schema = Schema.from_dict(schemas.load_schema(tap_stream_id))
-        metadata = []
-        for field_name in schema.properties.keys():
-            #print("field name=",field_name)
-            if field_name in schemas.PK_FIELDS[tap_stream_id]:
-                inclusion = 'automatic'
-            else:
-                inclusion = 'available'
-            metadata.append({
-                'metadata': {
-                    'inclusion': inclusion
-                },
-                'breadcrumb': ['properties', field_name]
-            })
-        catalog.streams.append(CatalogEntry(
-            stream=tap_stream_id,
-            tap_stream_id=tap_stream_id,
-            key_properties=schemas.PK_FIELDS[tap_stream_id],
-            schema=schema,
-            metadata=metadata
-        ))
-    return catalog
+        key_properties = schemas.PK_FIELDS[tap_stream_id]
+        schema = schemas.load_schema(tap_stream_id)
+        replication_method = schemas.REPLICATION_METHODS[tap_stream_id].get("replication_method")
+        replication_keys = schemas.REPLICATION_METHODS[tap_stream_id].get("replication_keys")
+        meta = metadata.get_standard_metadata(schema=schema,
+                                              key_properties=key_properties,
+                                              replication_method=replication_method,
+                                              valid_replication_keys=replication_keys)
+
+        meta = metadata.to_map(meta)
+
+        if replication_keys:
+            meta = metadata.write(meta, ('properties', replication_keys[0]), 'inclusion', 'automatic')
+
+        meta = metadata.to_list(meta)
+
+        streams.append({
+            'stream': tap_stream_id,
+            'tap_stream_id': tap_stream_id,
+            'key_properties': key_properties,
+            'schema': schema,
+            'metadata': meta,
+            'replication_method': replication_method,
+            'replication_key': replication_keys[0] if replication_keys else None
+        })
+    return Catalog.from_dict({'streams': streams})
 
 
 # this is already defined in schemas.py though w/o dependencies.  do we keep this for the sync?
@@ -81,17 +86,45 @@ def sync(atx):
     LOGGER.info('--------------------')
 
 
+def _compare_forms(config_forms, api_forms):
+    return config_forms.difference(api_forms)
+
+
+def _forms_to_list(config, keyword='forms'):
+    """Splits entries into a list and strips out surrounding blank spaces"""
+    return list(map(str.strip, config.get(keyword).split(',')))
+
+
+def validate_form_ids(config):
+    """Validate the form ids passed in the config"""
+    client = Client(config)
+
+    if not config.get('forms'):
+        LOGGER.fatal("No forms were provided in config")
+        raise NoFormsProvidedError
+
+    config_forms = set(_forms_to_list(config))
+    api_forms = {form.get('id') for form in client.get_forms()}
+
+    mismatched_forms = _compare_forms(config_forms, api_forms)
+
+    if len(mismatched_forms) > 0:
+        LOGGER.fatal(f"FormMistmatchError: forms {mismatched_forms} not returned by API")
+        raise FormMistmatchError
+
+
 @utils.handle_top_exception(LOGGER)
 def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     atx = Context(args.config, args.state)
     if args.discover:
+        validate_form_ids(args.config)
         # the schema is static from file so we don't need to pass in atx for connection info.
         catalog = discover()
-        json.dump(catalog.to_dict(), sys.stdout)
+        catalog.dump()
     else:
-        atx.catalog = Catalog.from_dict(args.properties) \
-            if args.properties else discover()
+        atx.catalog = args.catalog \
+            if args.catalog else discover()
         sync(atx)
 
 if __name__ == "__main__":

--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -4,28 +4,86 @@ import singer
 
 LOGGER = singer.get_logger()
 
-class RateLimitException(Exception):
+
+class TypeformError(Exception):
+    def __init__(self, message=None, response=None):
+        super().__init__(message)
+        self.message = message
+        self.response = response
+
+class TypeformBadRequestError(TypeformError):
     pass
 
-class MetricsRateLimitException(Exception):
+class TypeformUnauthorizedError(TypeformError):
     pass
+
+class TypeformForbiddenError(TypeformError):
+    pass
+
+class TypeformNotFoundError(TypeformError):
+    pass
+
+class TypeformTooManyError(TypeformError):
+    pass
+
+class TypeformInternalError(TypeformError):
+    pass
+
+class TypeformNotAvailableError(TypeformError):
+    pass
+
+
+ERROR_CODE_EXCEPTION_MAPPING = {
+    400: {
+        "raise_exception": TypeformBadRequestError,
+        "message": "A validation exception has occurred."
+    },
+    401: {
+        "raise_exception": TypeformUnauthorizedError,
+        "message": "Invalid authorization credentials."
+    },
+    403: {
+        "raise_exception": TypeformForbiddenError,
+        "message": "User doesn't have permission to access the resource."
+    },
+    404: {
+        "raise_exception": TypeformNotFoundError,
+        "message": "The resource you have specified cannot be found."
+    },
+    429: {
+        "raise_exception": TypeformTooManyError,
+        "message": "The API rate limit for your organisation/application pairing has been exceeded"
+    },
+    500: {
+        "raise_exception": TypeformInternalError,
+        "message": "An unhandled error with the Typeform API. Contact the Typeform API team if problems persist."
+    },
+    503: {
+        "raise_exception": TypeformNotAvailableError,
+        "message": "API service is currently unavailable."
+    }
+}
 
 class Client(object):
-    BASE_URL = 'https://api.typeform.com/forms/FORM_ID/responses'
+    BASE_URL = 'https://api.typeform.com'
 
     def __init__(self, config):
         self.token = 'Bearer ' + config.get('token')
         self.metric = config.get('metric')
         self.session = requests.Session()
 
-    def url(self, form_id):
-        return self.BASE_URL.replace("FORM_ID", form_id)
+    def build_url(self, endpoint):
+        return f"{self.BASE_URL}/{endpoint}"
 
     @backoff.on_exception(backoff.expo,
-                          RateLimitException,
-                          max_tries=10,
+                          (TypeformInternalError, TypeformNotAvailableError),
+                          max_tries=3,
                           factor=2)
-    def request(self, method, form_id, **kwargs):
+    @backoff.on_exception(backoff.expo,
+                          TypeformTooManyError,
+                          max_tries=3,
+                          factor=2)
+    def request(self, method, url, params=None, **kwargs):
         # note that typeform response api doesn't return limit headers
 
         if 'headers' not in kwargs:
@@ -33,25 +91,83 @@ class Client(object):
         if self.token:
             kwargs['headers']['Authorization'] = self.token
 
-        # if we're just pulling the form definition, strip the rest of the url
-        if 'params' not in kwargs:
-            response = requests.request(method, self.url(form_id).replace('/responses', ''), **kwargs)
-        else:
-            response = requests.request(method, self.url(form_id), **kwargs)
-        #print('final3 url=',response.url)
+        request = requests.Request(method, url, headers=kwargs['headers'], params=params)
 
-        if response.status_code in [429, 503]:
-            raise RateLimitException()
-        if response.status_code == 423:
-            raise MetricsRateLimitException()
-        try:
-            response.raise_for_status()
-        except:
-            LOGGER.error('{} - {}'.format(response.status_code, response.text))
-            raise
+        response = self.session.send(request.prepare())
+
+        if response.status_code != 200:
+            raise_for_error(response)
+            return None
+
         if 'total_items' in response.json():
             LOGGER.info('raw data items= {}'.format(response.json()['total_items']))
         return response.json()
 
-    def get(self, form_id, **kwargs):
-        return self.request('get', form_id, **kwargs)
+    # Max page size for forms API is 200
+    def get_forms(self, page_size=200):
+        url = self.build_url(endpoint='forms')
+        return self._get_forms('get', url, page_size)
+
+    def _get_forms(self, method, url, page_size):
+        page = 1
+        paginate = True
+        records = []
+        params = {'page_size': page_size}
+
+        while paginate:
+            params['page'] = page
+            response = self.request(method, url, params=params)
+            page_count = response.get('page_count')
+            paginate = page_count > page
+            page += 1
+
+            records += response.get('items')
+
+        return records
+
+    def get_form_definition(self, form_id, **kwargs):
+        endpoint = f"forms/{form_id}"
+        url = self.build_url(endpoint=endpoint)
+        return self.request('get', url, **kwargs)
+
+    def get_form_responses(self, form_id, **kwargs):
+        endpoint = f"forms/{form_id}/responses"
+        url = self.build_url(endpoint)
+        return self.request('get', url, **kwargs)
+
+
+def raise_for_error(response):
+    try:
+        response.raise_for_status()
+    except (requests.HTTPError, requests.ConnectionError) as error:
+        try:
+            error_code = response.status_code
+
+            # Handling status code 429 specially since the required information is present in the headers
+            if error_code == 429:
+                resp_headers = response.headers
+                api_rate_limit_message = ERROR_CODE_EXCEPTION_MAPPING[429]["message"]
+                message = "HTTP-error-code: 429, Error: {}. Please retry after {} seconds".format(api_rate_limit_message, resp_headers.get("Retry-After"))
+
+            # Handling status code 403 specially since response of API does not contain enough information
+            elif error_code in (403, 401):
+                api_message = ERROR_CODE_EXCEPTION_MAPPING[error_code]["message"]
+                message = "HTTP-error-code: {}, Error: {}".format(error_code, api_message)
+            else:
+                # Forming a response message for raising custom exception
+                try:
+                    response_json = response.json()
+                except Exception:
+                    response_json = {}
+
+                message = "HTTP-error-code: {}, Error: {}".format(
+                    error_code,
+                    response_json.get("description", "Uknown Error"))
+
+            exc = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("raise_exception", TypeformError)
+            message = ERROR_CODE_EXCEPTION_MAPPING.get(error_code, {}).get("message", "")
+            formatted_message = f"HTTP-error-code: {error_code}, Error: {message}"
+            raise exc(formatted_message, response) from None
+
+        except (ValueError, TypeError):
+            raise TypeformError(error) from None

--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -106,7 +106,8 @@ class Client(object):
     # Max page size for forms API is 200
     def get_forms(self, page_size=200):
         url = self.build_url(endpoint='forms')
-        return self._get_forms('get', url, page_size)
+        with singer.metrics.http_request_timer(endpoint=url):
+            return self._get_forms('get', url, page_size)
 
     def _get_forms(self, method, url, page_size):
         page = 1
@@ -128,12 +129,14 @@ class Client(object):
     def get_form_definition(self, form_id, **kwargs):
         endpoint = f"forms/{form_id}"
         url = self.build_url(endpoint=endpoint)
-        return self.request('get', url, **kwargs)
+        with singer.metrics.http_request_timer(endpoint=url):
+            return self.request('get', url, **kwargs)
 
     def get_form_responses(self, form_id, **kwargs):
         endpoint = f"forms/{form_id}/responses"
         url = self.build_url(endpoint)
-        return self.request('get', url, **kwargs)
+        with singer.metrics.http_request_timer(endpoint=url):
+            return self.request('get', url, **kwargs)
 
 
 def raise_for_error(response):

--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -130,13 +130,19 @@ class Client(object):
         endpoint = f"forms/{form_id}"
         url = self.build_url(endpoint=endpoint)
         with singer.metrics.http_request_timer(endpoint=url):
-            return self.request('get', url, **kwargs)
+            try:
+                return self.request('get', url, **kwargs)
+            except TypeformForbiddenError as err:
+                raise RuntimeError("Maybe add the Forms:Read scope to your token") from err
 
     def get_form_responses(self, form_id, **kwargs):
         endpoint = f"forms/{form_id}/responses"
         url = self.build_url(endpoint)
         with singer.metrics.http_request_timer(endpoint=url):
-            return self.request('get', url, **kwargs)
+            try:
+                return self.request('get', url, **kwargs)
+            except TypeformForbiddenError as err:
+                raise RuntimeError("Maybe add the Responses:Read scope to your token") from err
 
 
 def raise_for_error(response):

--- a/tap_typeform/schemas.py
+++ b/tap_typeform/schemas.py
@@ -8,17 +8,27 @@ class IDS(object):
     LANDINGS = 'landings'
     ANSWERS = 'answers'
     QUESTIONS = 'questions'
+    FORMS = 'forms'
 
 STATIC_SCHEMA_STREAM_IDS = [
     IDS.LANDINGS,
     IDS.ANSWERS,
-    IDS.QUESTIONS
+    IDS.QUESTIONS,
+    IDS.FORMS,
 ]
 
 PK_FIELDS = {
     IDS.LANDINGS: ['landing_id'],
     IDS.ANSWERS: ['landing_id', 'question_id'],
     IDS.QUESTIONS: ['form_id', 'question_id'],
+    IDS.FORMS: ['id']
+}
+
+REPLICATION_METHODS = {
+    IDS.LANDINGS: {"replication_method": "FULL_TABLE", "replication_keys": None},
+    IDS.ANSWERS: {"replication_method": "INCREMENTAL", "replication_keys": ["landed_at"]},
+    IDS.QUESTIONS: {"replication_method": "FULL_TABLE", "replication_keys": None},
+    IDS.FORMS: {"replication_method": "INCREMENTAL", "replication_keys": ["last_updated_at"]}
 }
 
 def normalize_fieldname(fieldname):

--- a/tap_typeform/schemas/answers.json
+++ b/tap_typeform/schemas/answers.json
@@ -1,33 +1,36 @@
 {
-    "type": ["null", "object"],
-    "selected": true,
-    "additionalProperties": false,
-    "properties": {
-	"landing_id": {
-	    "type": ["null", "string"],
-	    "selected": true
-	},
-	"question_id": {
-	    "type": ["null", "string"],
-	    "selected": true
-	},
-      	"type": {
-            "type": ["null", "string"],
-	    "selected": true
-	},
-      	"ref": {
-            "type": ["null", "string"],
-	    "selected": true
-	},
-      	"data_type": {
-            "type": ["null", "string"],
-	    "selected": true
-	},
-      	"answer": {
-            "type": ["null", "string"],
-	    "selected": true
-	}
+  "type": ["null", "object"],
+  "selected": true,
+  "additionalProperties": false,
+  "properties": {
+    "landing_id": {
+      "type": ["null", "string"],
+      "selected": true
     },
-    "key_properties": ["landing_id","question_id"],
-    "bookmark_properties": ["landing_id","question_id"]
+    "question_id": {
+      "type": ["null", "string"],
+      "selected": true
+    },
+    "type": {
+      "type": ["null", "string"],
+      "selected": true
+    },
+    "ref": {
+      "type": ["null", "string"],
+      "selected": true
+    },
+    "data_type": {
+      "type": ["null", "string"],
+      "selected": true
+    },
+    "landed_at": {
+      "type": ["null", "string"],
+      "selected": true
+    },
+    "answer": {
+      "type": ["null", "string"],
+      "selected": true
+    }
+  },
+  "key_properties": ["landing_id", "question_id"]
 }

--- a/tap_typeform/schemas/forms.json
+++ b/tap_typeform/schemas/forms.json
@@ -1,0 +1,94 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "title": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "last_updated_at": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "settings": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "is_public": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "is_trial": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "self": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "href": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "theme": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "href": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "_links": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "display": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -1,14 +1,12 @@
-import time
 import datetime
 import json
+import time
 
 import pendulum
 import singer
-from singer.bookmarks import write_bookmark, reset_stream
-from ratelimit import limits, sleep_and_retry, RateLimitException
-from backoff import on_exception, expo, constant
+from singer.bookmarks import write_bookmark
 
-from .http import MetricsRateLimitException
+from tap_typeform import schemas
 
 LOGGER = singer.get_logger()
 
@@ -66,17 +64,9 @@ def select_fields(mdata, obj):
             new_obj[key] = value
     return new_obj
 
-@on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
-@on_exception(expo, RateLimitException, max_tries=5)
-@sleep_and_retry
-@limits(calls=1, period=6) # 5 seconds needed to be padded by 1 second to work
 def get_form_definition(atx, form_id):
-    return atx.client.get(form_id)
+    return atx.client.get_form_definition(form_id)
 
-@on_exception(constant, MetricsRateLimitException, max_tries=5, interval=60)
-@on_exception(expo, RateLimitException, max_tries=5)
-@sleep_and_retry
-@limits(calls=1, period=6) # 5 seconds needed to be padded by 1 second to work
 def get_form(atx, form_id, start_date, end_date):
     LOGGER.info('Forms query - form: {} start_date: {} end_date: {} '.format(
         form_id,
@@ -86,7 +76,15 @@ def get_form(atx, form_id, start_date, end_date):
     # the api doesn't have a means of paging through responses if the number is greater than 1000,
     # so since the order of data retrieved is by submitted_at we have
     # to take the last submitted_at date and use it to cycle through
-    return atx.client.get(form_id, params={'since': start_date, 'until': end_date, 'page_size': 1000})
+    return atx.client.get_form_responses(form_id, params={'since': start_date, 'until': end_date, 'page_size': 1000})
+
+def get_forms(atx):
+    LOGGER.info('All forms query')
+    return atx.client.get_forms()
+
+def get_landings(atx, form_id):
+    LOGGER.info('All landings query')
+    return atx.client.get_form_responses(form_id)
 
 def sync_form_definition(atx, form_id):
     with singer.metrics.job_timer('form definition '+form_id):
@@ -133,12 +131,120 @@ def sync_form(atx, form_id, start_date, end_date):
             else:
                 time.sleep(METRIC_JOB_POLL_SLEEP)
 
-    landings_data_rows = []
     answers_data_rows = []
 
     max_submitted_dt = ''
 
     for row in data:
+
+        max_submitted_dt = row['submitted_at']
+
+        if row.get('answers') and 'answers' in atx.selected_stream_ids:
+            for answer in row['answers']:
+                data_type = answer.get('type')
+
+                if data_type in ['choice', 'choices', 'payment']:
+                    answer_value = json.dumps(answer.get(data_type))
+                elif data_type in ['number', 'boolean']:
+                    answer_value = str(answer.get(data_type))
+                else:
+                    answer_value = answer.get(data_type)
+
+                answers_data_rows.append({
+                    "landing_id": row.get('landing_id'),
+                    "question_id": answer.get('field',{}).get('id'),
+                    "type": answer.get('field',{}).get('type'),
+                    "ref": answer.get('field',{}).get('ref'),
+                    "data_type": data_type,
+                    "landed_at": row.get("landed_at"),
+                    "answer": answer_value
+                })
+
+    if 'answers' in atx.selected_stream_ids:
+        write_records(atx, 'answers', answers_data_rows)
+
+    return [response['total_items'], max_submitted_dt]
+
+
+def write_forms_state(atx, stream_name, form_id, value):
+    if isinstance(value, dict):
+        write_bookmark(atx.state, stream_name, form_id, value)
+    else:
+        write_bookmark(atx.state, stream_name, form_id, value.to_datetime_string())
+    atx.write_state()
+
+
+def sync_latest_forms(atx):
+    replication_key = 'last_updated_at'
+    tap_id = 'forms'
+    with singer.metrics.job_timer('all forms'):
+        start = time.monotonic()
+        while True:
+            if (time.monotonic() - start) >= MAX_METRIC_JOB_TIME:
+                raise Exception('Metric job timeout ({} secs)'.format(
+                    MAX_METRIC_JOB_TIME))
+            forms = get_forms(atx)
+            if forms != '':
+                break
+            else:
+                time.sleep(METRIC_JOB_POLL_SLEEP)
+
+    # Using an older version of singer
+    bookmark_date = singer.get_bookmark(atx.state, tap_id, replication_key) or atx.config['start_date']
+    bookmark_datetime = singer.utils.strptime_to_utc(bookmark_date)
+    max_datetime = bookmark_datetime
+
+    records = []
+    for form in forms:
+        record_datetime = singer.utils.strptime_to_utc(form[replication_key])
+        if record_datetime >= bookmark_datetime:
+            records.append(form)
+            max_datetime = max(record_datetime, max_datetime)
+
+    write_records(atx, tap_id, records)
+    bookmark_date = singer.utils.strftime(max_datetime)
+    state = singer.write_bookmark(atx.state,
+                                  tap_id,
+                                  replication_key,
+                                  bookmark_date)
+
+    return state
+
+
+def is_incremental(stream):
+    return schemas.REPLICATION_METHODS[stream].get("replication_method") == "INCREMENTAL"
+
+
+def get_replication_key(stream):
+    if is_incremental(stream):
+        return schemas.REPLICATION_METHODS[stream].get("replication_keys")[0]
+    return None
+
+
+def construct_bookmark(stream_name, value):
+    replication_key = get_replication_key(stream_name)
+    if replication_key:
+        bookmark_value = {replication_key: value.to_datetime_string()}
+    else:
+        bookmark_value = value
+
+    return bookmark_value
+
+def get_bookmark_value(state, stream_name, key, default=None):
+    # singer.get_bookmark(atx.state, stream_name, form_id, default=s_d)
+    bookmark = singer.get_bookmark(state, stream_name, key, default=default)
+
+    if isinstance(bookmark, dict):
+        return list(bookmark.values())[0]
+
+    return bookmark
+
+
+def sync_landings(atx, form_id):
+    response = get_landings(atx, form_id)
+    landings_data_rows = []
+
+    for row in response['items']:
         if 'hidden' not in row:
             hidden = ''
         else:
@@ -160,51 +266,23 @@ def sync_form(atx, form_id, start_date, end_date):
                 "hidden": hidden
             })
 
-        max_submitted_dt = row['submitted_at']
+    write_records(atx, 'landings', landings_data_rows)
 
-        if row.get('answers') and 'answers' in atx.selected_stream_ids:
-            for answer in row['answers']:
-                data_type = answer.get('type')
-
-                if data_type in ['choice', 'choices', 'payment']:
-                    answer_value = json.dumps(answer.get(data_type))
-                elif data_type in ['number', 'boolean']:
-                    answer_value = str(answer.get(data_type))
-                else:
-                    answer_value = answer.get(data_type)
-
-                answers_data_rows.append({
-                    "landing_id": row.get('landing_id'),
-                    "question_id": answer.get('field',{}).get('id'),
-                    "type": answer.get('field',{}).get('type'),
-                    "ref": answer.get('field',{}).get('ref'),
-                    "data_type": data_type,
-                    "answer": answer_value
-                })
-
-    if 'landings' in atx.selected_stream_ids:
-        write_records(atx, 'landings', landings_data_rows)
-    if 'answers' in atx.selected_stream_ids:
-        write_records(atx, 'answers', answers_data_rows)
-
-    return [response['total_items'], max_submitted_dt]
-
-
-def write_forms_state(atx, form, date_to_resume):
-    write_bookmark(atx.state, form, 'date_to_resume', date_to_resume.to_datetime_string())
-    atx.write_state()
 
 def sync_forms(atx):
     incremental_range = atx.config.get('incremental_range')
 
     for form_id in atx.config.get('forms').split(','):
-        bookmark = atx.state.get('bookmarks', {}).get(form_id, {})
+        # bookmark = atx.state.get('bookmarks', {}) atx.stream_name, {})
 
         LOGGER.info('form: {} '.format(form_id))
 
         # pull back the form question details
         if 'questions'in atx.selected_stream_ids:
             sync_form_definition(atx, form_id)
+
+        if 'landings' in atx.selected_stream_ids:
+            sync_landings(atx, form_id)
 
         should_sync_forms = False
         for stream_name in FORM_STREAMS:
@@ -240,7 +318,7 @@ def sync_forms(atx):
         # if the state file has a date_to_resume, we use it as it is.
         # if it doesn't exist, we overwrite by start date
         s_d = start_date.strftime("%Y-%m-%d %H:%M:%S")
-        last_date = pendulum.parse(bookmark.get('date_to_resume', s_d))
+        last_date = pendulum.parse(get_bookmark_value(atx.state, stream_name, form_id, default=s_d))
         LOGGER.info('last_date: {} '.format(last_date))
 
 
@@ -264,16 +342,19 @@ def sync_forms(atx):
             # but this also might cause some minor loss of data.
             # there's no ideal scenario here since the API has no other way than using
             # time ranges to step through data.
+            bookmark_value = construct_bookmark(stream_name, next_date)
+
             while responses == 1000:
                 interim_next_date = pendulum.parse(max_submitted_at) + datetime.timedelta(seconds=1)
                 ut_interim_next_date = int(interim_next_date.timestamp())
-                write_forms_state(atx, form_id, interim_next_date)
+                bookmark_value = construct_bookmark(stream_name, interim_next_date)
+                write_forms_state(atx, stream_name, form_id, bookmark_value)
                 [responses, max_submitted_at] = sync_form(atx, form_id, ut_interim_next_date, ut_next_date)
 
             # if the prior sync is successful it will write the date_to_resume bookmark
-            write_forms_state(atx, form_id, next_date)
+            write_forms_state(atx, stream_name, form_id, bookmark_value)
             current_date = next_date
 
-        reset_stream(atx.state, 'questions')
-        reset_stream(atx.state, 'landings')
-        reset_stream(atx.state, 'answers')
+    if 'forms'in atx.selected_stream_ids:
+        state = sync_latest_forms(atx)
+        singer.write_state(state)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,312 @@
+"""
+Setup expectations for test sub classes
+Run discovery for as a prerequisite for most tests
+"""
+import unittest
+import os
+from datetime import timedelta
+from datetime import datetime as dt
+
+from singer import get_logger
+from tap_tester import connections, menagerie, runner
+
+
+class TypeformBaseTest(unittest.TestCase):
+    """
+    Setup expectations for test sub classes.
+    Metadata describing streams.
+    A bunch of shared methods that are used in tap-tester tests.
+    Shared tap-specific methods (as needed).
+    """
+    AUTOMATIC_FIELDS = "automatic"
+    REPLICATION_KEYS = "valid-replication-keys"
+    PRIMARY_KEYS = "table-key-properties"
+    FOREIGN_KEYS = "table-foreign-key-properties"
+    REPLICATION_METHOD = "forced-replication-method"
+    API_LIMIT = "max-row-limit"
+    INCREMENTAL = "INCREMENTAL"
+    FULL_TABLE = "FULL_TABLE"
+    START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+    BOOKMARK_COMPARISON_FORMAT = "%Y-%m-%dT00:00:00+00:00"
+    LOGGER = get_logger()
+
+    start_date = '2021-05-10T00:00:00Z'
+
+    @staticmethod
+    def tap_name():
+        """The name of the tap"""
+        return "tap-typeform"
+
+    @staticmethod
+    def get_type():
+        """the expected url route ending"""
+        return "platform.typeform"
+
+    def get_properties(self, original: bool = True):
+        """Configuration properties required for the tap."""
+        return_value = {
+            'start_date' : '2021-05-10T00:00:00Z',
+            'forms': os.getenv('TAP_TYPEFORM_FORMS'),
+            'incremental_range': 'daily',
+        }
+        if original:
+            return return_value
+
+        return_value["start_date"] = self.start_date
+        return return_value
+
+    def get_forms(self):
+        forms = self.get_properties()['forms']
+        return forms.split(',')
+
+    @staticmethod
+    def get_credentials():
+        """Authentication information for the test account"""
+        return {'token': os.getenv('TAP_TYPEFORM_TOKEN')}
+
+    def expected_metadata(self):
+        """The expected streams and metadata about the streams"""
+        return {
+            "answers": {
+                self.PRIMARY_KEYS: {"landing_id", "question_id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"landed_at"}
+            },
+            "landings": {
+                self.PRIMARY_KEYS: {"landing_id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "questions": {
+                self.PRIMARY_KEYS: {"form_id", "question_id"},
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+            },
+            "forms": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"last_updated_at"}
+            }
+        }
+
+    def expected_streams(self):
+        """A set of expected stream names"""
+        return set(self.expected_metadata().keys())
+
+    def child_streams(self):
+        """
+        Return a set of streams that are child streams
+        based on having foreign key metadata
+        """
+        return {stream for stream, metadata in self.expected_metadata().items()
+                if metadata.get(self.FOREIGN_KEYS)}
+
+    def expected_primary_keys(self):
+        """
+        return a dictionary with key of table name
+        and value as a set of primary key fields
+        """
+        return {table: properties.get(self.PRIMARY_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_replication_keys(self):
+        """
+        return a dictionary with key of table name
+        and value as a set of replication key fields
+        """
+        return {table: properties.get(self.REPLICATION_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_foreign_keys(self):
+        """
+        return a dictionary with key of table name
+        and value as a set of foreign key fields
+        """
+        return {table: properties.get(self.FOREIGN_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_automatic_fields(self):
+        auto_fields = {}
+        for k, v in self.expected_metadata().items():
+            auto_fields[k] = v.get(self.PRIMARY_KEYS, set()) | v.get(self.REPLICATION_KEYS, set()) \
+                | v.get(self.FOREIGN_KEYS, set())
+        return auto_fields
+
+    def expected_replication_method(self):
+        """return a dictionary with key of table name nd value of replication method"""
+        return {table: properties.get(self.REPLICATION_METHOD, None)
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def setUp(self):
+        missing_envs = [x for x in [os.getenv('TAP_TYPEFORM_TOKEN')] if x is None]
+        if len(missing_envs) != 0:
+            raise Exception("set environment variables")
+
+
+    #########################
+    #   Helper Methods      #
+    #########################
+
+    def run_and_verify_check_mode(self, conn_id):
+        """
+        Run the tap in check mode and verify it succeeds.
+        This should be ran prior to field selection and initial sync.
+        Return the connection id and found catalogs from menagerie.
+        """
+        # run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['stream_name'], found_catalogs))
+
+        self.assertSetEqual(self.expected_streams(), found_catalog_names, msg="discovered schemas do not match")
+        print("discovered schemas are OK")
+
+        return found_catalogs
+
+    def run_and_verify_sync(self, conn_id):
+        """
+        Run a sync job and make sure it exited properly.
+        Return a dictionary with keys of streams synced
+        and values of records synced for each stream
+        """
+        # Run a sync job using orchestrator
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        # Verify actual rows were synced
+        sync_record_count = runner.examine_target_output_file(
+            self, conn_id, self.expected_streams(), self.expected_primary_keys())
+        self.assertGreater(
+            sum(sync_record_count.values()), 0,
+            msg="failed to replicate any data: {}".format(sync_record_count)
+        )
+        print("total replicated row count: {}".format(sum(sync_record_count.values())))
+
+        return sync_record_count
+
+    def perform_and_verify_table_and_field_selection(self,
+                                                     conn_id,
+                                                     test_catalogs,
+                                                     select_all_fields=True):
+        """
+        Perform table and field selection based off of the streams to select
+        set and field selection parameters.
+        Verify this results in the expected streams selected and all or no
+        fields selected for those streams.
+        """
+
+        # Select all available fields or select no fields from all testable streams
+        self.select_all_streams_and_fields(
+            conn_id=conn_id, catalogs=test_catalogs, select_all_fields=select_all_fields
+        )
+
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Ensure our selection affects the catalog
+        expected_selected = [tc.get('stream_name') for tc in test_catalogs]
+        for cat in catalogs:
+            catalog_entry = menagerie.get_annotated_schema(conn_id, cat['stream_id'])
+
+            # Verify all testable streams are selected
+            selected = catalog_entry.get('annotated-schema').get('selected')
+            print("Validating selection on {}: {}".format(cat['stream_name'], selected))
+            if cat['stream_name'] not in expected_selected:
+                self.assertFalse(selected, msg="Stream selected, but not testable.")
+                continue # Skip remaining assertions if we aren't selecting this stream
+            self.assertTrue(selected, msg="Stream not selected.")
+
+            if select_all_fields:
+                # Verify all fields within each selected stream are selected
+                for field, field_props in catalog_entry.get('annotated-schema').get('properties').items():
+                    field_selected = field_props.get('selected')
+                    print("\tValidating selection on {}.{}: {}".format(
+                        cat['stream_name'], field, field_selected))
+                    self.assertTrue(field_selected, msg="Field not selected.")
+            else:
+                # Verify only automatic fields are selected
+                expected_automatic_fields = self.expected_automatic_fields().get(cat['stream_name'])
+                selected_fields = self.get_selected_fields_from_metadata(catalog_entry['metadata'])
+                self.assertEqual(expected_automatic_fields, selected_fields)
+
+    @staticmethod
+    def get_selected_fields_from_metadata(metadata):
+        selected_fields = set()
+        for field in metadata:
+            is_field_metadata = len(field['breadcrumb']) > 1
+            inclusion_automatic_or_selected = (
+                field['metadata']['selected'] is True or \
+                field['metadata']['inclusion'] == 'automatic'
+            )
+            if is_field_metadata and inclusion_automatic_or_selected:
+                selected_fields.add(field['breadcrumb'][1])
+        return selected_fields
+
+
+    @staticmethod
+    def select_all_streams_and_fields(conn_id, catalogs, select_all_fields: bool = True):
+        """Select all streams and all fields within streams"""
+        for catalog in catalogs:
+            schema = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+
+            non_selected_properties = []
+            if not select_all_fields:
+                # get a list of all properties so that none are selected
+                non_selected_properties = schema.get('annotated-schema', {}).get(
+                    'properties', {}).keys()
+
+            connections.select_catalog_and_fields_via_metadata(
+                conn_id, catalog, schema, [], non_selected_properties)
+
+    @staticmethod
+    def parse_date(date_value):
+        """
+        Pass in string-formatted-datetime, parse the value, and return it as an unformatted datetime object.
+        """
+        date_formats = {
+            "%Y-%m-%dT%H:%M:%S.%fZ",
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%dT%H:%M:%S.%f+00:00",
+            "%Y-%m-%dT%H:%M:%S+00:00",
+            "%Y-%m-%d"
+        }
+        for date_format in date_formats:
+            try:
+                date_stripped = dt.strptime(date_value, date_format)
+                return date_stripped
+            except ValueError:
+                continue
+
+        raise NotImplementedError("Tests do not account for dates of this format: {}".format(date_value))
+
+    def timedelta_formatted(self, dtime, days=0):
+        try:
+            date_stripped = dt.strptime(dtime, self.START_DATE_FORMAT)
+            return_date = date_stripped + timedelta(days=days)
+
+            return dt.strftime(return_date, self.START_DATE_FORMAT)
+
+        except ValueError:
+            try:
+                date_stripped = dt.strptime(dtime, self.BOOKMARK_COMPARISON_FORMAT)
+                return_date = date_stripped + timedelta(days=days)
+
+                return dt.strftime(return_date, self.BOOKMARK_COMPARISON_FORMAT)
+
+            except ValueError:
+                return Exception("Datetime object is not of the format: {}".format(self.START_DATE_FORMAT))
+
+    ##########################################################################
+    ### Tap Specific Methods
+    ##########################################################################

--- a/tests/test_typeform_automatic_fields.py
+++ b/tests/test_typeform_automatic_fields.py
@@ -1,0 +1,66 @@
+"""
+Test that with no fields selected for a stream automatic fields are still replicated
+"""
+import os
+
+from tap_tester import runner, connections
+
+from base import TypeformBaseTest
+
+
+class TypeformAutomaticFields(TypeformBaseTest):
+    """Test that with no fields selected for a stream automatic fields are still replicated"""
+
+    @staticmethod
+    def name():
+        return "tap_tester_typeform_automatic_fields"
+
+    def test_run(self):
+        """
+        Verify that for each stream you can get multiple pages of data
+        when no fields are selected and only the automatic fields are replicated.
+        PREREQUISITE
+        For EACH stream add enough data that you surpass the limit of a single
+        fetch of data.  For instance if you have a limit of 250 records ensure
+        that 251 (or more) records have been posted for that stream.
+        """
+
+        expected_streams = self.expected_streams()
+
+        # instantiate connection
+        conn_id = connections.ensure_connection(self)
+
+        # run check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        test_catalogs_automatic_fields = [catalog for catalog in found_catalogs
+                                          if catalog.get('stream_name') in expected_streams]
+
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, test_catalogs_automatic_fields, select_all_fields=False,
+        )
+
+        # run initial sync
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        synced_records = runner.get_records_from_target_output()
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_keys = self.expected_automatic_fields().get(stream)
+
+                # collect actual values
+                data = synced_records.get(stream)
+                record_messages_keys = [set(row['data'].keys()) for row in data['messages']]
+
+
+                # Verify that you get some records for each stream
+                self.assertGreater(
+                    record_count_by_stream.get(stream, -1), 0,
+                    msg="The number of records is not over the stream max limit")
+
+                # Verify that only the automatic fields are sent to the target
+                for actual_keys in record_messages_keys:
+                    self.assertSetEqual(expected_keys, actual_keys)

--- a/tests/test_typeform_bookmarks.py
+++ b/tests/test_typeform_bookmarks.py
@@ -1,0 +1,272 @@
+import os
+import datetime
+import dateutil.parser
+import pytz
+
+from tap_tester import runner, menagerie, connections
+
+from base import TypeformBaseTest
+
+
+class TypeformBookmarks(TypeformBaseTest):
+
+    @staticmethod
+    def name():
+        return "tap_tester_typeform_bookmarks"
+
+    @staticmethod
+    def convert_state_to_utc(date_str):
+        """
+        Convert a saved bookmark value of the form '2020-08-25T13:17:36-07:00' to
+        a string formatted utc datetime,
+        in order to compare aginast json formatted datetime values
+        """
+        date_object = dateutil.parser.parse(date_str)
+        date_object_utc = date_object.astimezone(tz=pytz.UTC)
+        return datetime.datetime.strftime(date_object_utc, "%Y-%m-%dT%H:%M:%SZ")
+
+    def calculated_states_by_stream(self, current_state):
+        """
+        Look at the bookmarks from a previous sync and set a new bookmark
+        value based off timedelta expectations. This ensures the subsequent sync will replicate
+        at least 1 record but, fewer records than the previous sync.
+        Sufficient test data is required for this test to cover a given stream.
+        An incrmeental replication stream must have at least two records with
+        replication keys that differ by more than the lookback window.
+        If the test data is changed in the future this will break expectations for this test.
+        The following streams barely make the cut:
+        campaigns "2021-02-09T18:17:30.000000Z"
+                  "2021-02-09T16:24:58.000000Z"
+        adsets    "2021-02-09T18:17:41.000000Z"
+                  "2021-02-09T17:10:09.000000Z"
+        leads     '2021-04-07T20:09:39+0000',
+                  '2021-04-07T20:08:27+0000',
+        """
+        timedelta_by_stream = {stream: [25,0,0]  # {stream_name: [days, hours, minutes], ...}
+                               for stream in self.expected_streams()}
+        expected_replication_keys = self.expected_replication_keys()
+
+        stream_to_calculated_state = {stream: "" for stream in current_state['bookmarks'].keys()}
+        for stream, state in current_state['bookmarks'].items():
+            for state_key in state.keys():
+                if stream != "forms":
+                    replication_key = next(iter(expected_replication_keys[stream]))
+                    state_as_datetime = dateutil.parser.parse(state[state_key][replication_key])
+                else:
+                    state_as_datetime = dateutil.parser.parse(state[state_key])
+
+                days, hours, minutes = timedelta_by_stream[stream]
+                calculated_state_as_datetime = state_as_datetime - datetime.timedelta(days=days, hours=hours, minutes=minutes)
+
+                state_format = '%Y-%m-%dT%H:%M:%S-00:00'
+                calculated_state_formatted = datetime.datetime.strftime(calculated_state_as_datetime, state_format)
+
+                if stream_to_calculated_state.get(stream) == "":
+                    stream_to_calculated_state[stream] = {state_key: calculated_state_formatted}
+                else:
+                    stream_to_calculated_state[stream][state_key] = calculated_state_formatted
+
+        return stream_to_calculated_state
+
+
+    def test_run(self):
+        expected_streams =  self.expected_streams()
+
+        expected_replication_keys = self.expected_replication_keys()
+        expected_replication_methods = self.expected_replication_method()
+
+        ##########################################################################
+        ### First Sync
+        ##########################################################################
+        self.start_date_1 = self.get_properties().get("start_date")
+        self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=3)
+
+        self.start_date = self.start_date_1
+        conn_id = connections.ensure_connection(self, original_properties=False)
+
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # Select only the expected streams tables
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries, select_all_fields=True)
+
+        # Run a sync job using orchestrator
+        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        first_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        ### Update State Between Syncs
+        ##########################################################################
+
+        new_states = {'bookmarks': dict()}
+        simulated_states = self.calculated_states_by_stream(first_sync_bookmarks)
+        for stream, new_state in simulated_states.items():
+            new_states['bookmarks'][stream] = new_state
+        menagerie.set_state(conn_id, new_states)
+
+        for stream in simulated_states.keys():
+            for state_key, state_value in simulated_states[stream].items():
+                if stream not in new_states['bookmarks']:
+                    new_states['bookmarks'][stream] = {}
+                if state_key not in new_states['bookmarks'][stream]:
+                    new_states['bookmarks'][stream][state_key] = state_value
+
+
+        ##########################################################################
+        ### Second Sync
+        ##########################################################################
+        self.start_date = self.start_date_2
+
+        # run check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        test_catalogs_2_all_fields = [catalog for catalog in found_catalogs
+                                      if catalog.get('tap_stream_id') in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id, test_catalogs_2_all_fields, select_all_fields=True)
+
+        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        ### Test By Stream
+        ##########################################################################
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+                expected_replication_method = expected_replication_methods[stream]
+                first_bookmark_key_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+                second_bookmark_key_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+
+                # expected values
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                first_sync_messages = [record.get('data') for record in
+                                    first_sync_records.get(stream).get('messages')
+                                    if record.get('action') == 'upsert']
+                second_sync_messages = [record.get('data') for record in
+                                        second_sync_records.get(stream).get('messages')
+                                        if record.get('action') == 'upsert']
+
+                if expected_replication_method == self.INCREMENTAL:
+
+
+                    replication_key = next(iter(expected_replication_keys[stream]))
+
+                    if stream != 'forms':
+                        for form_key in self.get_forms():
+                            first_bookmark_value = first_bookmark_key_value.get(form_key, {}).get(replication_key)
+                            second_bookmark_value = second_bookmark_key_value.get(form_key, {}).get(replication_key)
+                            first_bookmark_value_utc = self.convert_state_to_utc(first_bookmark_value)
+                            second_bookmark_value_utc = self.convert_state_to_utc(second_bookmark_value)
+                            simulated_bookmark_value = new_states['bookmarks'][stream][form_key]
+                            simulated_bookmark_minus_lookback = simulated_bookmark_value
+
+
+                            # Verify the first sync sets a bookmark of the expected form
+                            self.assertIsNotNone(first_bookmark_key_value)
+
+                            # Verify the second sync sets a bookmark of the expected form
+                            self.assertIsNotNone(second_bookmark_key_value)
+
+                            # Verify the second sync bookmark is Equal to the first sync bookmark
+                            self.assertEqual(second_bookmark_value, first_bookmark_value) # assumes no changes to data during test
+
+
+                            for record in second_sync_messages:
+
+                                # Verify the second sync records respect the previous (simulated) bookmark value
+                                replication_key_value = record.get(replication_key)
+                                self.assertGreaterEqual(replication_key_value, simulated_bookmark_minus_lookback,
+                                                        msg="Second sync records do not repect the previous bookmark.")
+
+                                # Verify the second sync bookmark value is the max replication key value for a given stream
+                                self.assertLessEqual(
+                                    replication_key_value, second_bookmark_value_utc,
+                                    msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                                )
+
+                            for record in first_sync_messages:
+                                # Verify the first sync bookmark value is the max replication key value for a given stream
+                                replication_key_value = record.get(replication_key)
+                                self.assertLessEqual(
+                                    replication_key_value, first_bookmark_value_utc,
+                                    msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                                )
+
+
+                            # Verify the number of records in the 2nd sync is less then the first
+                            self.assertLess(second_sync_count, first_sync_count)
+
+                    else:
+                        # collect information specific to incremental streams from syncs 1 & 2
+                        first_bookmark_value = first_bookmark_key_value.get(replication_key)
+                        second_bookmark_value = second_bookmark_key_value.get(replication_key)
+                        first_bookmark_value_utc = self.convert_state_to_utc(first_bookmark_value)
+                        second_bookmark_value_utc = self.convert_state_to_utc(second_bookmark_value)
+                        simulated_bookmark_value = new_states['bookmarks'][stream][replication_key]
+                        simulated_bookmark_minus_lookback = simulated_bookmark_value
+
+                    # Verify the first sync sets a bookmark of the expected form
+                    self.assertIsNotNone(first_bookmark_key_value)
+
+                    # Verify the second sync sets a bookmark of the expected form
+                    self.assertIsNotNone(second_bookmark_key_value)
+
+                    # Verify the second sync bookmark is Equal to the first sync bookmark
+                    self.assertEqual(second_bookmark_value, first_bookmark_value) # assumes no changes to data during test
+
+
+                    for record in second_sync_messages:
+
+                        # Verify the second sync records respect the previous (simulated) bookmark value
+                        replication_key_value = record.get(replication_key)
+                        self.assertGreaterEqual(replication_key_value, simulated_bookmark_minus_lookback,
+                                                msg="Second sync records do not repect the previous bookmark.")
+
+                        # Verify the second sync bookmark value is the max replication key value for a given stream
+                        self.assertLessEqual(
+                            replication_key_value, second_bookmark_value_utc,
+                            msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                        )
+
+                    for record in first_sync_messages:
+
+                        # Verify the first sync bookmark value is the max replication key value for a given stream
+                        replication_key_value = record.get(replication_key)
+                        self.assertLessEqual(
+                            replication_key_value, first_bookmark_value_utc,
+                            msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                        )
+
+
+                    # Verify the number of records in the 2nd sync is less then the first
+                    self.assertLess(second_sync_count, first_sync_count)
+
+
+                elif expected_replication_method == self.FULL_TABLE:
+
+
+                    # Verify the syncs do not set a bookmark for full table streams
+                    self.assertIsNone(first_bookmark_key_value)
+                    self.assertIsNone(second_bookmark_key_value)
+
+                    # Verify the number of records in the second sync is the same as the first
+                    self.assertEqual(second_sync_count, first_sync_count)
+
+
+                else:
+
+
+                    raise NotImplementedError(
+                        "INVALID EXPECTATIONS\t\tSTREAM: {} REPLICATION_METHOD: {}".format(stream, expected_replication_method)
+                    )
+
+
+                # Verify at least 1 record was replicated in the second sync
+                self.assertGreater(second_sync_count, 0, msg="We are not fully testing bookmarking for {}".format(stream))

--- a/tests/test_typeform_discovery.py
+++ b/tests/test_typeform_discovery.py
@@ -1,0 +1,105 @@
+"""Test tap discovery mode and metadata."""
+import re
+
+from tap_tester import menagerie, connections
+
+from base import TypeformBaseTest
+
+
+class DiscoveryTest(TypeformBaseTest):
+    """Test tap discovery mode and metadata conforms to standards."""
+
+    @staticmethod
+    def name():
+        return "tap_tester_typeform_discovery_test"
+
+    def test_run(self):
+        """
+        Testing that discovery creates the appropriate catalog with valid metadata.
+        • Verify number of actual streams discovered match expected
+        • Verify the stream names discovered were what we expect
+        • Verify stream names follow naming convention
+          streams should only have lowercase alphas and underscores
+        • verify there is only 1 top level breadcrumb
+        • verify replication key(s)
+        • verify primary key(s)
+        • verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
+        • verify the actual replication matches our expected replication method
+        • verify that primary, replication and foreign keys
+          are given the inclusion of automatic.
+        • verify that all other fields have inclusion of available metadata.
+        """
+        streams_to_test = self.expected_streams()
+
+        conn_id = connections.ensure_connection(self)
+
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # Verify stream names follow naming convention
+        # streams should only have lowercase alphas and underscores
+        found_catalog_names = {c['tap_stream_id'] for c in found_catalogs}
+        self.assertTrue(all([re.fullmatch(r"[a-z_]+",  name) for name in found_catalog_names]),
+                        msg="One or more streams don't follow standard naming")
+
+        for stream in streams_to_test:
+            with self.subTest(stream=stream):
+
+                # Verify ensure the caatalog is found for a given stream
+                catalog = next(iter([catalog for catalog in found_catalogs
+                                     if catalog["stream_name"] == stream]))
+                self.assertIsNotNone(catalog)
+
+                # collecting expected values
+                expected_primary_keys = self.expected_primary_keys()[stream]
+                expected_replication_keys = self.expected_replication_keys()[stream]
+                expected_automatic_fields = expected_primary_keys | expected_replication_keys
+                expected_replication_method = self.expected_replication_method()[stream]
+
+                # collecting actual values...
+                schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+                metadata = schema_and_metadata["metadata"]
+                stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+                if len(stream_properties) == 0:
+                    stream_properties.append({})
+                actual_primary_keys = set(
+                    stream_properties[0].get(
+                        "metadata", {self.PRIMARY_KEYS: []}).get(self.PRIMARY_KEYS, [])
+                )
+                actual_replication_keys = set(
+                    stream_properties[0].get(
+                        "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, [])
+                )
+                actual_replication_method = stream_properties[0].get(
+                    "metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
+                actual_automatic_fields = set(
+                    item.get("breadcrumb", ["properties", None])[1] for item in metadata
+                    if item.get("metadata").get("inclusion") == "automatic"
+                )
+
+                ##########################################################################
+                ### metadata assertions
+                ##########################################################################
+
+                # verify there is only 1 top level breadcrumb in metadata
+                self.assertTrue(len(stream_properties) == 1,
+                                msg="There is NOT only one top level breadcrumb for {}".format(stream) + \
+                                "\nstream_properties | {}".format(stream_properties))
+
+                # verify primary key(s) match expectations
+                self.assertSetEqual(
+                    expected_primary_keys, actual_primary_keys,
+                )
+
+                # verify that primary keys and replication keys
+                # are given the inclusion of automatic in metadata.
+                self.assertSetEqual(expected_automatic_fields, actual_automatic_fields)
+
+                # verify that all other fields have inclusion of available
+                # This assumes there are no unsupported fields for SaaS sources
+                self.assertTrue(
+                    all({item.get("metadata").get("inclusion") == "available"
+                         for item in metadata
+                         if item.get("breadcrumb", []) != []
+                         and item.get("breadcrumb", ["properties", None])[1]
+                         not in actual_automatic_fields}),
+                    msg="Not all non key properties are set to available in metadata")

--- a/tests/test_typeform_start_date.py
+++ b/tests/test_typeform_start_date.py
@@ -1,0 +1,93 @@
+import os
+
+from tap_tester import connections, runner
+
+from base import TypeformBaseTest
+
+
+class TypeformStartDateTest(TypeformBaseTest):
+
+    @staticmethod
+    def name():
+        return "tap_tester_typeform_start_date_test"
+
+    def test_run(self):
+        """Instantiate start date according to the desired data set and run the test"""
+
+        self.start_date_1 = self.get_properties().get("start_date")
+        self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=3)
+
+        self.start_date = self.start_date_1
+
+        expected_streams = self.expected_streams()
+
+        ##########################################################################
+        ### First Sync
+        ##########################################################################
+
+        # instantiate connection
+        conn_id_1 = connections.ensure_connection(self)
+
+        # run check mode
+        found_catalogs_1 = self.run_and_verify_check_mode(conn_id_1)
+
+        # table and field selection
+        test_catalogs_1_all_fields = [catalog for catalog in found_catalogs_1
+                                      if catalog.get('tap_stream_id') in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id_1, test_catalogs_1_all_fields, select_all_fields=True)
+
+        # run initial sync
+        record_count_by_stream_1 = self.run_and_verify_sync(conn_id_1)
+        synced_records_1 = runner.get_records_from_target_output()
+
+        ##########################################################################
+        ### Update START DATE Between Syncs
+        ##########################################################################
+
+        print("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(self.start_date, self.start_date_2))
+        self.start_date = self.start_date_2
+
+        ##########################################################################
+        ### Second Sync
+        ##########################################################################
+
+        # create a new connection with the new start_date
+        conn_id_2 = connections.ensure_connection(self, original_properties=False)
+
+        # run check mode
+        found_catalogs_2 = self.run_and_verify_check_mode(conn_id_2)
+
+        # table and field selection
+        test_catalogs_2_all_fields = [catalog for catalog in found_catalogs_2
+                                      if catalog.get('tap_stream_id') in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id_2, test_catalogs_2_all_fields, select_all_fields=True)
+
+        # run sync
+        record_count_by_stream_2 = self.run_and_verify_sync(conn_id_2)
+        synced_records_2 = runner.get_records_from_target_output()
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+                expected_replication_methods = self.expected_replication_method()
+                expected_replication_method = expected_replication_methods[stream]
+
+                # expected values
+                expected_primary_keys = self.expected_primary_keys()[stream]
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                record_count_sync_1 = record_count_by_stream_1.get(stream, 0)
+                record_count_sync_2 = record_count_by_stream_2.get(stream, 0)
+                primary_keys_list_1 = [tuple(message.get('data').get(expected_pk) for expected_pk in expected_primary_keys)
+                                       for message in synced_records_1.get(stream).get('messages')
+                                       if message.get('action') == 'upsert']
+                primary_keys_list_2 = [tuple(message.get('data').get(expected_pk) for expected_pk in expected_primary_keys)
+                                       for message in synced_records_2.get(stream).get('messages')
+                                       if message.get('action') == 'upsert']
+                primary_keys_sync_1 = set(primary_keys_list_1)
+                primary_keys_sync_2 = set(primary_keys_list_2)
+
+                if expected_replication_method == self.INCREMENTAL:
+
+                    self.assertLess(record_count_sync_2, record_count_sync_1)
+                else:
+                    self.assertEqual(record_count_sync_2, record_count_sync_1)

--- a/tests/unittests/test_compare.py
+++ b/tests/unittests/test_compare.py
@@ -1,0 +1,24 @@
+from tap_typeform import _compare_forms, _forms_to_list
+
+
+def test_validate_form_ids():
+    test_cases = [
+        {'case': {'abc', 'def', 'ghi'}, 'valid': {'abc', 'def'}, 'expected': {'ghi'}},
+        {'case': {'xyz', 'tuv', 'qrs'}, 'valid': {'xyz'}, 'expected': {'tuv', 'qrs'}},
+        {'case': {'one', 'two', 'three'}, 'valid': set(), 'expected': {'one', 'two', 'three'}},
+        {'case': {'a', 'b', 'c'}, 'valid': {'a', 'b', 'c'}, 'expected': set()},
+    ]
+
+    for test_case in test_cases:
+        assert test_case['expected'] == _compare_forms(test_case['case'], test_case['valid'])
+
+
+def test_forms_to_list():
+    test_cases = [
+        {'case': {'forms': 'abc,def,ghi'}, 'expected': ['abc', 'def', 'ghi']},
+        {'case': {'forms': 'abc, def, ghi'}, 'expected': ['abc', 'def', 'ghi']},
+        {'case': {'forms': '   abc , def , ghi     '}, 'expected': ['abc', 'def', 'ghi']},
+    ]
+
+    for test_case in test_cases:
+        assert test_case['expected'] == _forms_to_list(test_case['case'])

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,245 @@
+import unittest
+from unittest import mock
+
+import requests
+import tap_typeform.http as client_
+
+
+
+def mocked_session(*args, **kwargs):
+    class Mocksession:
+        def __init__(self, json_data, status_code, content, headers, raise_error):
+            self.text = json_data
+            self.status_code = status_code
+            self.raise_error = raise_error
+            if headers:
+                self.headers = headers
+
+        def raise_for_status(self):
+            if not self.raise_error:
+                return self.status_code
+
+            raise requests.HTTPError("sample message")
+
+        def json(self):
+            return self.text
+
+    arguments_to_session = args[0]
+
+    json_data = arguments_to_session[0]
+    status_code = arguments_to_session[1]
+    content = arguments_to_session[2]
+    headers = arguments_to_session[3]
+    raise_error = arguments_to_session[4]
+    return Mocksession(json_data, status_code, content, headers, raise_error)
+
+
+class Mockresponse:
+    def __init__(self, resp, status_code, content=[], headers=None, raise_error=False):
+        self.json_data = resp
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+        self.raise_error = raise_error
+
+    def prepare(self):
+        return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("sample message")
+
+
+def mocked_badrequest_400_error(*args, **kwargs):
+    json_decode_str = {"code": "VALIDATION_ERROR"}
+
+    return Mockresponse(json_decode_str, 400, raise_error=True)
+
+
+def mocked_unauthorized_401_error(*args, **kwargs):
+    json_decode_str = {"code": "UNAUTHORIZED", "description": "Authentication credentials not found on the Request Headers"}
+
+    return Mockresponse(json_decode_str, 401, raise_error=True)
+
+
+def mocked_forbidden_403_exception(*args, **kwargs):
+    json_decode_str = {"code": "AUTHENTICATION_FAILED", "description": "Authentication failed"}
+
+    return Mockresponse(json_decode_str, 403, raise_error=True)
+
+
+def mocked_notfound_404_error(*args, **kwargs):
+    json_decode_str = {"code": "NOT_FOUND", "description": "Endpoint not found"}
+
+    return Mockresponse(json_decode_str, 404, raise_error=True)
+
+
+def mocked_failed_429_request(*args, **kwargs):
+    json_decode_str = ''
+    headers = {"Retry-After": 1000, "X-Rate-Limit-Problem": "day"}
+    return Mockresponse(json_decode_str, 429, headers=headers, raise_error=True)
+
+
+def mocked_internalservererror_500_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 500, raise_error=True)
+
+
+def mocked_notimplemented_501_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 501, raise_error=True)
+
+
+def mocked_not_available_503_error(*args, **kwargs):
+    json_decode_str = {}
+
+    return Mockresponse(json_decode_str, 503, raise_error=True)
+
+
+@mock.patch('requests.Session.send', side_effect=mocked_session)
+class TestClientExceptionHandling(unittest.TestCase):
+    """
+    Test cases to verify if the exceptions are handled as expected while communicating with Xero Environment 
+    """
+    endpoint = "forms"
+
+    @mock.patch('requests.Request', side_effect=mocked_badrequest_400_error)
+    def test_badrequest_400_error(self, mocked_session, mocked_badrequest_400_error):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except client_.TypeformBadRequestError as e:
+            expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
+
+            # Verifying the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_unauthorized_401_error)
+    def test_unauthorized_401_error(self, mocked_session, mocked_unauthorized_401_error):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except client_.TypeformUnauthorizedError as e:
+            expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+
+            # Verifying the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_forbidden_403_exception)
+    def test_forbidden_403_exception(self, mocked_session, mocked_forbidden_403_exception):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except client_.TypeformForbiddenError as e:
+            expected_error_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
+
+            # Verifying the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_notfound_404_error)
+    def test_notfound_404_error(self, mocked_session, mocked_notfound_404_error):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except client_.TypeformNotFoundError as e:
+            expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
+
+            # Verifying the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    def test_internalservererror_500_error(self, mocked_session, mocked_internalservererror_500_error):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except client_.TypeformInternalError as e:
+            expected_error_message = "HTTP-error-code: 500, Error: An unhandled error with the Typeform API. Contact the Typeform API team if problems persist."
+
+            # Verifying the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_not_available_503_error)
+    def test_not_available_503_error(self, mocked_session, mocked_not_available_503_error):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except client_.TypeformNotAvailableError as e:
+            expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+
+            # Verifying the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request)
+    def test_too_many_requests_429(self, mocked_session, mocked_failed_429_request):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except client_.TypeformTooManyError as e:
+            expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded"
+            
+            # Verifying the message formed for the custom exception
+            self.assertEqual(str(e), expected_error_message)
+            pass
+
+
+    @mock.patch('requests.Request', side_effect=mocked_failed_429_request)
+    def test_too_many_requests_429_backoff_behavior(self, mocked_session, mocked_failed_429_request):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except (requests.HTTPError, client_.TypeformTooManyError) as e:
+            pass
+
+        #Verify daily limit should not backoff
+        self.assertEqual(mocked_failed_429_request.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+
+    @mock.patch('requests.Request', side_effect=mocked_internalservererror_500_error)
+    def test_internalservererror_500_backoff_behaviour(self, mocked_session, mocked_internalservererror_500_error):
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except (requests.HTTPError, client_.TypeformInternalError) as e:
+            pass
+
+        self.assertEqual(mocked_internalservererror_500_error.call_count, 3)
+        self.assertEqual(mocked_session.call_count, 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

This PR 
* Makes the code equivalent to `v1.3.0` again
* Adds context in failure scenarios for certain requests.

# Manual QA Steps
I generated 3 tokens with different sets of scopes
1. `Accounts:Read`
2. `Forms:Read`
3. `Forms:Read` and `Responses:Read`

I ran the tap with each token in the order described above. Note that each time the tap made it father "into" the code

## The logs to prove we need more scopes on the token

### `Accounts:Read`                  

``` sh
INFO form: t6sbkCIz
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.3381948471069336, "tags": {"job_type": "form definition t6sbkCIz", "status": "failed"}}
CRITICAL HTTP-error-code: 403, Error: User doesn't have permission to access the resource.
Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-typeform/bin/tap-typeform", line 33, in <module>
    sys.exit(load_entry_point('tap-typeform', 'console_scripts', 'tap-typeform')())
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 128, in main
    sync(atx)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 81, in sync
    streams.sync_forms(atx)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 282, in sync_forms
    sync_form_definition(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 96, in sync_form_definition
    response = get_form_definition(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 68, in get_form_definition
    return atx.client.get_form_definition(form_id)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 131, in get_form_definition
    return self.request('get', url, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 99, in request
    raise_for_error(response)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 170, in raise_for_error
    raise exc(formatted_message, response) from None
tap_typeform.http.TypeformForbiddenError: HTTP-error-code: 403, Error: User doesn't have permission to access the resource.
```

### `Forms:Read`

``` sh
INFO form: t6sbkCIz
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.32311463356018066, "tags": {"job_type": "form definition t6sbkCIz", "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 2, "tags": {"endpoint": "questions"}}
INFO All landings query
CRITICAL HTTP-error-code: 403, Error: User doesn't have permission to access the resource.
Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-typeform/bin/tap-typeform", line 33, in <module>
    sys.exit(load_entry_point('tap-typeform', 'console_scripts', 'tap-typeform')())
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 128, in main
    sync(atx)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 81, in sync
    streams.sync_forms(atx)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 285, in sync_forms
    sync_landings(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 244, in sync_landings
    response = get_landings(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 87, in get_landings
    return atx.client.get_form_responses(form_id)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 136, in get_form_responses
    return self.request('get', url, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 99, in request
    raise_for_error(response)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 170, in raise_for_error
    raise exc(formatted_message, response) from None
tap_typeform.http.TypeformForbiddenError: HTTP-error-code: 403, Error: User doesn't have permission to access the resource.
```

### `Forms:Read` and `Responses:Read`

``` sh
INFO form: t6sbkCIz
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.2069098949432373, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz", "status": "succeeded"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.20743322372436523, "tags": {"job_type": "form definition t6sbkCIz", "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 2, "tags": {"endpoint": "questions"}}
INFO All landings query
INFO raw data items= 0
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.0352473258972168, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz/responses", "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 0, "tags": {"endpoint": "landings"}}
INFO Forms query - form: t6sbkCIz start_date: 2021-05-10 00:00 end_date: 2021-05-11 00:00
INFO raw data items= 0
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.030831575393676758, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz/responses", "status": "succeeded"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.031381845474243164, "tags": {"job_type": "form t6sbkCIz", "status": "succeeded"}}
```

## The new and improved logs

### `Accounts:Read`                  

``` sh
INFO form: t6sbkCIz
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 1.006927490234375, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz", "status": "failed"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 1.0073966979980469, "tags": {"job_type": "form definition t6sbkCIz", "status": "failed"}}
CRITICAL Maybe add the Forms:Read scope to your token
Traceback (most recent call last):
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 134, in get_form_definition
    return self.request('get', url, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 99, in request
    raise_for_error(response)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 179, in raise_for_error
    raise exc(formatted_message, response) from None
tap_typeform.http.TypeformForbiddenError: HTTP-error-code: 403, Error: User doesn't have permission to access the resource.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-typeform/bin/tap-typeform", line 33, in <module>
    sys.exit(load_entry_point('tap-typeform', 'console_scripts', 'tap-typeform')())
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 128, in main
    sync(atx)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 81, in sync
    streams.sync_forms(atx)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 282, in sync_forms
    sync_form_definition(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 96, in sync_form_definition
    response = get_form_definition(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 68, in get_form_definition
    return atx.client.get_form_definition(form_id)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 136, in get_form_definition
    raise RuntimeError("Maybe add the Forms:Read scope to your token") from err
RuntimeError: Maybe add the Forms:Read scope to your token     
```

### `Forms:Read`                     

``` sh
INFO form: t6sbkCIz
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.1775655746459961, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz", "status": "succeeded"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.17805051803588867, "tags": {"job_type": "form definition t6sbkCIz", "status": "succeeded"}}
{"type": "RECORD", "stream": "questions", "record": {"form_id": "t6sbkCIz", "question_id": "e4hDM6IBIpyw"}, "time_extracted": "2021-07-27T03:32:02.618334Z"}
{"type": "RECORD", "stream": "questions", "record": {"form_id": "t6sbkCIz", "question_id": "IIYseA58pKxJ"}, "time_extracted": "2021-07-27T03:32:02.618334Z"}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 2, "tags": {"endpoint": "questions"}}
INFO All landings query
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.01852250099182129, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz/responses", "status": "failed"}}
CRITICAL Maybe add the Responses:Read scope to your token
Traceback (most recent call last):
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 143, in get_form_responses
    return self.request('get', url, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 99, in request
    raise_for_error(response)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 179, in raise_for_error
    raise exc(formatted_message, response) from None
tap_typeform.http.TypeformForbiddenError: HTTP-error-code: 403, Error: User doesn't have permission to access the resource.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/share/virtualenvs/tap-typeform/bin/tap-typeform", line 33, in <module>
    sys.exit(load_entry_point('tap-typeform', 'console_scripts', 'tap-typeform')())
  File "/usr/local/share/virtualenvs/tap-typeform/lib/python3.8/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 128, in main
    sync(atx)
  File "/opt/code/tap-typeform/tap_typeform/__init__.py", line 81, in sync
    streams.sync_forms(atx)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 285, in sync_forms
    sync_landings(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 244, in sync_landings
    response = get_landings(atx, form_id)
  File "/opt/code/tap-typeform/tap_typeform/streams.py", line 87, in get_landings
    return atx.client.get_form_responses(form_id)
  File "/opt/code/tap-typeform/tap_typeform/http.py", line 145, in get_form_responses
    raise RuntimeError("Maybe add the Responses:Read scope to your token") from err
RuntimeError: Maybe add the Responses:Read scope to your token     
```

### `Forms:Read` and `Responses:Read`

``` sh
INFO form: t6sbkCIz
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.3422980308532715, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz", "status": "succeeded"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.34274935722351074, "tags": {"job_type": "form definition t6sbkCIz", "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 2, "tags": {"endpoint": "questions"}}
INFO All landings query
INFO raw data items= 0
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.034545183181762695, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz/responses", "status": "succeeded"}}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 0, "tags": {"endpoint": "landings"}}
INFO Forms query - form: t6sbkCIz start_date: 2021-05-10 00:00 end_date: 2021-05-11 00:00
INFO raw data items= 0
INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.03435397148132324, "tags": {"endpoint": "https://api.typeform.com/forms/t6sbkCIz/responses", "status": "succeeded"}}
INFO METRIC: {"type": "timer", "metric": "job_duration", "value": 0.034932851791381836, "tags": {"job_type": "form t6sbkCIz", "status": "succeeded"}}
```

# Risks

It appeared that the release of `v1.3.0` affected the scopes on the tokens somehow. Because tap runs that would previously succeed on `v1.2.0` failed on `v1.3.0` and `v1.3.2`.

Since things are broken, this PR should be very low risk because it only helps people help themselves

# Rollback Steps

Revert the commit and bump the version
