### PR TITLE
Change pagination strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ tags
 singer-check-tap-data
 state*.json
 catalog*.json
+
+# VSCode
+.vscode/

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -321,7 +321,7 @@ def sync_forms(atx):
         # if there's no default date and it gets set to now
         now = datetime.datetime.now(pytz.utc)
         s_d = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        start_date = pendulum.parse(atx.config.get('start_date', s_d))
+        start_date = pendulum.parse(atx.config.get('start_date', s_d.isoformat()))
 
         # if the state file has a date_to_resume, we use it as it is.
         # if it doesn't exist, we overwrite by start date
@@ -358,7 +358,7 @@ def sync_forms(atx):
 
         # check if bookmark is in the past
         now_parsed = pendulum.parse(now.isoformat())
-        updated_bookmark_value = now_parsed if parsed_max_submitted_at < now_parsed else parsed_max_submitted_at
+        updated_bookmark_value = max(parsed_max_submitted_at, now_parsed)
         bookmark_value = construct_bookmark(stream_name, updated_bookmark_value)
 
         # if the prior sync is successful it will write the date_to_resume bookmark

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -356,6 +356,11 @@ def sync_forms(atx):
             bookmark_value = construct_bookmark(stream_name, parsed_max_submitted_at)
             write_forms_state(atx, stream_name, form_id, bookmark_value)
 
+        # check if bookmark_value is in the past
+        now_parsed = pendulum.parse(now.isoformat())
+        updated_bookmark_value = now_parsed if parsed_max_submitted_at < now_parsed else bookmark_value
+        bookmark_value = bookmark_value = construct_bookmark(stream_name, updated_bookmark_value)
+
         # if the prior sync is successful it will write the date_to_resume bookmark
         write_forms_state(atx, stream_name, form_id, bookmark_value)
 

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -162,7 +162,7 @@ def sync_form(atx, form_id, start_date, token=None, next_page=False):
 
     answers_data_rows = []
 
-    max_submitted_dt = ''
+    max_submitted_dt = datetime.datetime.fromtimestamp(start_date).isoformat()
     max_token = ''
 
     for row in data:

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import time
 
@@ -162,7 +161,7 @@ def sync_form(atx, form_id, start_date, token=None, next_page=False):
 
     answers_data_rows = []
 
-    max_submitted_dt = datetime.datetime.fromtimestamp(start_date).isoformat()
+    max_submitted_dt = pendulum.from_timestamp(start_date).isoformat()
     max_token = ''
 
     for row in data:
@@ -319,8 +318,8 @@ def sync_forms(atx):
 
         # start_date is defaulted in the config file 2018-01-01
         # if there's no default date and it gets set to now
-        now = datetime.datetime.now(pytz.utc)
-        s_d = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        now_parsed = pendulum.now(pytz.utc)
+        s_d = now_parsed.replace(hour=0, minute=0, second=0, microsecond=0)
         start_date = pendulum.parse(atx.config.get('start_date', s_d.isoformat()))
 
         # if the state file has a date_to_resume, we use it as it is.
@@ -357,7 +356,6 @@ def sync_forms(atx):
             write_forms_state(atx, stream_name, form_id, bookmark_value)
 
         # check if bookmark is in the past
-        now_parsed = pendulum.parse(now.isoformat())
         updated_bookmark_value = max(parsed_max_submitted_at, now_parsed)
         bookmark_value = construct_bookmark(stream_name, updated_bookmark_value)
 

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -356,10 +356,10 @@ def sync_forms(atx):
             bookmark_value = construct_bookmark(stream_name, parsed_max_submitted_at)
             write_forms_state(atx, stream_name, form_id, bookmark_value)
 
-        # check if bookmark_value is in the past
+        # check if bookmark is in the past
         now_parsed = pendulum.parse(now.isoformat())
-        updated_bookmark_value = now_parsed if parsed_max_submitted_at < now_parsed else bookmark_value
-        bookmark_value = bookmark_value = construct_bookmark(stream_name, updated_bookmark_value)
+        updated_bookmark_value = now_parsed if parsed_max_submitted_at < now_parsed else parsed_max_submitted_at
+        bookmark_value = construct_bookmark(stream_name, updated_bookmark_value)
 
         # if the prior sync is successful it will write the date_to_resume bookmark
         write_forms_state(atx, stream_name, form_id, bookmark_value)

--- a/tests/test_typeform_bookmarks.py
+++ b/tests/test_typeform_bookmarks.py
@@ -174,8 +174,8 @@ class TypeformBookmarks(TypeformBaseTest):
                             # Verify the second sync sets a bookmark of the expected form
                             self.assertIsNotNone(second_bookmark_key_value)
 
-                            # Verify the second sync bookmark is Equal to the first sync bookmark
-                            self.assertEqual(second_bookmark_value, first_bookmark_value) # assumes no changes to data during test
+                            # Verify the second sync bookmark is Greater or Equal to the first sync bookmark
+                            self.assertGreaterEqual(second_bookmark_value, first_bookmark_value) # new responses could be picked up for the form in the second sync
 
 
                             for record in second_sync_messages:
@@ -218,8 +218,8 @@ class TypeformBookmarks(TypeformBaseTest):
                     # Verify the second sync sets a bookmark of the expected form
                     self.assertIsNotNone(second_bookmark_key_value)
 
-                    # Verify the second sync bookmark is Equal to the first sync bookmark
-                    self.assertEqual(second_bookmark_value, first_bookmark_value) # assumes no changes to data during test
+                    # Verify the second sync bookmark is Greater or Equal to the first sync bookmark
+                    self.assertGreaterEqual(second_bookmark_value, first_bookmark_value) # new responses could be picked up for the form in the second sync
 
 
                     for record in second_sync_messages:


### PR DESCRIPTION
# Description of change
Adjust tap pagination strategy to use `after` param for syncing the answers stream ([TDL-15006](https://jira.talendforge.org/browse/TDL-15006))

# Manual QA steps
 - ran tap locally, singer-check-tap, and with target-stitch --dry-run
 - tap-tester and CircleCI passing
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
