### PR TITLE
Bump to v1.4.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+  * Update the tap to make less requests and ask for bigger batches of data per response [#44](https://github.com/singer-io/tap-typeform/pull/44)
+  * Fix bookmarking bug. Bookmarks will never be set in the future now [#43](https://github.com/singer-io/tap-typeform/pull/43)
+
 ## 1.3.2
   * This version actually reverts the code back to `v1.2.0` [#39](https://github.com/singer-io/tap-typeform/pull/39)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="1.3.2",
+    version="1.4.0",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
This is the version bump PR for #44  and #43.

## 1.4.0
  * Update the tap to make less requests and ask for bigger batches of data per response [#44](https://github.com/singer-io/tap-typeform/pull/44)
  * Fix bookmarking bug. Bookmarks will never be set in the future now [#43](https://github.com/singer-io/tap-typeform/pull/43)

# Manual QA steps
 - See #44 and #43 
 
# Risks
 - See #44 and #43 
 
# Rollback steps
 - revert #44 and/or #43 and bump the version
