### PR TITLE
Fix IndexError bug in landings pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.2
+  * Fixes IndexError in `landings` pagination [#51](https://github.com/singer-io/tap-typeform/pull/51)
+
 ## 1.4.1
   * Adds pagination to the `landings` stream [#48](https://github.com/singer-io/tap-typeform/pull/48)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="1.4.1",
+    version="1.4.2",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -133,7 +133,7 @@ def get_landings(atx, form_id):
             token = items[-1].get('token')
 
 
-        yield from response.get('items', [])
+        yield from items
 
 
 def sync_form_definition(atx, form_id):

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -128,7 +128,10 @@ def get_landings(atx, form_id):
 
         page_count = response.get('page_count', 1)
         sort = None
-        token = response.get('items', [])[-1].get('token')
+        items = response.get('items', [])
+        if items:
+            token = items[-1].get('token')
+
 
         yield from response.get('items', [])
 


### PR DESCRIPTION
# Description of change
The `items` default to empty list was indexed on and to get an IndexError. This pr checks if `items` is empty first. 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
