### PR TITLE
TDL - 16279 Implement request timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,9 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            pip install nose
-            nosetests tests/unittests
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_typeform --cover-html-dir=htmlcov tests/unittests
+            coverage html
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - add_ssh_keys
@@ -31,14 +31,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-typeform \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     --token=$STITCH_API_TOKEN \
-                     tests
+            run-test --tap=tap-typeform tests
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ jobs:
             pip install nose coverage
             nosetests --with-coverage --cover-erase --cover-package=tap_typeform --cover-html-dir=htmlcov tests/unittests
             coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - run:
           name: 'Integration Tests'
           command: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python3 ./setup.py install
 
 ## Configuration
 
-This tap requires a `config.json` which specifies details regarding an [Authentication token](https://developer.typeform.com/get-started/convert-keys-to-access-tokens/), a list of form ids, a start date for syncing historical data (date format of YYYY-MM-DDTHH:MI:SSZ), and a time period range [daily,hourly] to control what incremental extract date ranges are. See [example.config.json](example.config.json) for an example.
+This tap requires a `config.json` which specifies details regarding an [Authentication token](https://developer.typeform.com/get-started/convert-keys-to-access-tokens/), a list of form ids, a start date for syncing historical data (date format of YYYY-MM-DDTHH:MI:SSZ), request_timeout for which request should wait to get response(It is an optional parameter and default request_timeout is 300 seconds) and a time period range [daily,hourly] to control what incremental extract date ranges are. See [example.config.json](example.config.json) for an example.
 
 Create the catalog:
 

--- a/example.config.json
+++ b/example.config.json
@@ -2,6 +2,7 @@
   "token": "<myapitoken>",
   "start_date": "2018-01-01T00:00:00Z",
   "forms": "ZFuC6U,bFPlvG,WFBGBZ,WF0XE6,xFWoCE,OFHRwO,QFh3FI",
+  "request_timeout": 300,
   "incremental_range": "daily"
 }
 

--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -2,10 +2,11 @@ import requests
 import backoff
 import singer
 
-from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ChunkedEncodingError, Timeout
 
 LOGGER = singer.get_logger()
 
+REQUEST_TIMEOUT = 300
 
 class TypeformError(Exception):
     def __init__(self, message=None, response=None):
@@ -73,13 +74,20 @@ class Client(object):
         self.token = 'Bearer ' + config.get('token')
         self.metric = config.get('metric')
         self.session = requests.Session()
+        # Set request timeout to config param `request_timeout` value.
+        # If value is 0,"0","" or not passed then it set default to 300 seconds.
+        config_request_timeout = config.get('request_timeout')
+        if config_request_timeout and float(config_request_timeout):
+            self.request_timeout = float(config_request_timeout)
+        else:
+            self.request_timeout = REQUEST_TIMEOUT
 
     def build_url(self, endpoint):
         return f"{self.BASE_URL}/{endpoint}"
 
     @backoff.on_exception(backoff.expo,
                           (TypeformInternalError, TypeformNotAvailableError,
-                           TypeformTooManyError, ChunkedEncodingError),
+                           TypeformTooManyError, ChunkedEncodingError, Timeout), # Backoff for request timeout
                           max_tries=3,
                           factor=2)
     def request(self, method, url, params=None, **kwargs):
@@ -92,7 +100,7 @@ class Client(object):
 
         request = requests.Request(method, url, headers=kwargs['headers'], params=params)
 
-        response = self.session.send(request.prepare())
+        response = self.session.send(request.prepare(), timeout=self.request_timeout)# Pass request timeout
 
         if response.status_code != 200:
             raise_for_error(response)

--- a/tap_typeform/http.py
+++ b/tap_typeform/http.py
@@ -74,13 +74,12 @@ class Client(object):
         self.token = 'Bearer ' + config.get('token')
         self.metric = config.get('metric')
         self.session = requests.Session()
-        # Set request timeout to config param `request_timeout` value.
-        # If value is 0,"0","" or not passed then it set default to 300 seconds.
+        # Set and pass request timeout to config param `request_timeout` value.
         config_request_timeout = config.get('request_timeout')
         if config_request_timeout and float(config_request_timeout):
             self.request_timeout = float(config_request_timeout)
         else:
-            self.request_timeout = REQUEST_TIMEOUT
+            self.request_timeout = REQUEST_TIMEOUT # If value is 0,"0","" or not passed then it set default to 300 seconds.
 
     def build_url(self, endpoint):
         return f"{self.BASE_URL}/{endpoint}"
@@ -94,7 +93,7 @@ class Client(object):
                             Timeout,
                           max_tries=5,
                           factor=2)
-    def request(self, method, url, params=None, req=300, **kwargs):
+    def request(self, method, url, params=None, **kwargs):
         # note that typeform response api doesn't return limit headers
 
         if 'headers' not in kwargs:
@@ -104,7 +103,7 @@ class Client(object):
 
         request = requests.Request(method, url, headers=kwargs['headers'], params=params)
 
-        response = self.session.send(request.prepare(), timeout=req)# Pass request timeout
+        response = self.session.send(request.prepare(), timeout=self.request_timeout)# Pass request timeout
 
         if response.status_code != 200:
             raise_for_error(response)

--- a/tests/test_typeform_bookmarks.py
+++ b/tests/test_typeform_bookmarks.py
@@ -44,9 +44,11 @@ class TypeformBookmarks(TypeformBaseTest):
         """
         # The `answers` stream sets the bookmark as the date when the sync was ran. However, after
         # 25th October 2021, there was no record found for `answers` stream. Hence, we altered the
-        # state to set a bookmark so that it never goes beyon 25th October.
+        # state to set a bookmark so that it never goes beyond 25th October, however for the `forms` 
+        # stream the bookmark is updated based on the last record. Thus the new state updated based 
+        # on stream.
         date_difference = (datetime.datetime.now() - datetime.datetime(2021, 10, 25, 00, 00, 00)).days
-        timedelta_by_stream = {stream: [date_difference,0,0]  # {stream_name: [days, hours, minutes], ...}
+        timedelta_by_stream = {stream: [(date_difference if stream == 'answers' else 25), 0, 0]  # {stream_name: [days, hours, minutes], ...}
                                for stream in self.expected_streams()}
         expected_replication_keys = self.expected_replication_keys()
 

--- a/tests/test_typeform_bookmarks.py
+++ b/tests/test_typeform_bookmarks.py
@@ -42,7 +42,11 @@ class TypeformBookmarks(TypeformBaseTest):
         leads     '2021-04-07T20:09:39+0000',
                   '2021-04-07T20:08:27+0000',
         """
-        timedelta_by_stream = {stream: [25,0,0]  # {stream_name: [days, hours, minutes], ...}
+        # The `answers` stream sets the bookmark as the date when the sync was ran. However, after
+        # 25th October 2021, there was no record found for `answers` stream. Hence, we altered the
+        # state to set a bookmark so that it never goes beyon 25th October.
+        date_difference = (datetime.datetime.now() - datetime.datetime(2021, 10, 25, 00, 00, 00)).days
+        timedelta_by_stream = {stream: [date_difference,0,0]  # {stream_name: [days, hours, minutes], ...}
                                for stream in self.expected_streams()}
         expected_replication_keys = self.expected_replication_keys()
 

--- a/tests/test_typeform_bookmarks.py
+++ b/tests/test_typeform_bookmarks.py
@@ -42,11 +42,11 @@ class TypeformBookmarks(TypeformBaseTest):
         leads     '2021-04-07T20:09:39+0000',
                   '2021-04-07T20:08:27+0000',
         """
-        # The `answers` stream sets the bookmark as the date when the sync was ran. However, after
+        # The `answers` stream sets the bookmark as the date when the sync was run. However, after
         # 25th October 2021, there was no record found for `answers` stream. Hence, we altered the
-        # state to set a bookmark so that it never goes beyond 25th October, however for the `forms` 
-        # stream the bookmark is updated based on the last record. Thus the new state updated based 
-        # on stream.
+        # state to set a bookmark so that it never goes beyond 25th October, however for the `forms`
+        # stream the bookmark is updated based on the last record. Thus the new state is updated based
+        # on the stream.
         date_difference = (datetime.datetime.now() - datetime.datetime(2021, 10, 25, 00, 00, 00)).days
         timedelta_by_stream = {stream: [(date_difference if stream == 'answers' else 25), 0, 0]  # {stream_name: [days, hours, minutes], ...}
                                for stream in self.expected_streams()}

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,155 +1,164 @@
 import unittest
 from unittest.mock import patch
 
-from requests.exceptions import Timeout, ConnectionError
+import requests
 import tap_typeform.http as client_
 
 REQUEST_TIMEOUT_INT = 300
 REQUEST_TIMEOUT_STR = "300"
-REQUEST_TIMEOUT_FLOAT = 300.05
+REQUEST_TIMEOUT_FLOAT = 300.0
+
+# Mock response object
+def get_mock_http_response(*args, **kwargs):
+    contents = '{"accounts":[{"id": 12}]}'
+    response = requests.Response()
+    response.status_code = 200
+    response._content = contents.encode()
+    return response
 
 @patch('time.sleep')
-class TestRequestTimeouts(unittest.TestCase):
+@patch('requests.Session.send', side_effect = get_mock_http_response)
+@patch('requests.Request.prepare')
+class TestRequestTimeoutsValue(unittest.TestCase):
     
     endpoint = "forms"
-
-    @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_string_value_in_config(self, mocked_request, mock_sleep):
+    def test_request_timeout_for_string_value_in_config(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        5 times when stiring "300" value of `request_timeout` passed
+            Verify that if request_timeout is provided in config(string value) then it should be use
         """
         config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_STR}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
-        try:
-            client.request('GET', url)
-        except Timeout as e:
-            pass
+        
+        # Call request method which call requests.Session.request with timeout
+        client.request('GET', url)
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        # Verify requests.Session.send is called with expected timeout
+        args, kwargs = mock_send.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
+
     
-    @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_int_value_in_config(self, mocked_request, mock_sleep):
+    def test_request_timeout_for_int_value_in_config(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        5 times when int 300 value of `request_timeout` passed
+            Verify that if request_timeout is provided in config(integer value) then it should be use
         """
         config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_INT}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
-        try:
-            client.request('GET', url)
-        except Timeout as e:
-            pass
+        # Call request method which call requests.Session.send with timeout
+        client.request('GET', url)
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        # Verify requests.Session.send is called with expected timeout
+        args, kwargs = mock_send.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
         
-    @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_float_value_in_config(self, mocked_request, mock_sleep):
+    def test_request_timeout_for_float_value_in_config(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        5 times when float 300.05 value of `request_timeout` passed
+            Verify that if request_timeout is provided in config(float value) then it should be use
         """
         config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_FLOAT}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
-        try:
-            client.request('GET', url)
-        except Timeout as e:
-            pass
+        # Call request method which call requests.Session.send with timeout
+        client.request('GET', url)
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        # Verify requests.Session.send is called with expected timeout
+        args, kwargs = mock_send.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
 
-    @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_empty_string_value_in_config(self, mocked_request, mock_sleep):
+    def test_request_timeout_for_empty_string_value_in_config(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        5 times when empty string value of `request_timeout` passed
+            Verify that if request_timeout is provided in config with empty string then default value is used
         """
         config = {'token': '123', "request_timeout": ""}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
-        try:
-            client.request('GET', url)
-        except Timeout as e:
-            pass
+        # Call request method which call requests.Session.send with timeout
+        client.request('GET', url)
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        # Verify requests.Session.send is called with expected timeout
+        args, kwargs = mock_send.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
         
-    @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_zero_string_value_in_config(self, mocked_request, mock_sleep):
+    def test_request_timeout_for_zero_string_value_in_config(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        5 times when zero string value of `request_timeout` passed
+            Verify that if request_timeout is provided in config with zero in string format then default value is used
         """
         config = {'token': '123', "request_timeout": "0"}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
-        try:
-            client.request('GET', url)
-        except Timeout as e:
-            pass
+        # Call request method which call requests.Session.send with timeout
+        client.request('GET', url)
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        # Verify requests.Session.send is called with expected timeout
+        args, kwargs = mock_send.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
         
-    @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_zero_int_value_in_config(self, mocked_request, mock_sleep):
+    def test_request_timeout_for_zero_int_value_in_config(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        5 times when int 0 value of `request_timeout` passed
-        """        
+            Verify that if request_timeout is provided in config with zero value then default value is used
+        """       
         config = {'token': '123', "request_timeout": 0}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
-        try:
-            client.request('GET', url)
-        except Timeout as e:
-            pass
+        # Call request method which call requests.Session.send with timeout
+        client.request('GET', url)
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
-        
-    @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_none_value_in_config(self, mocked_request, mock_sleep):
+        # Verify requests.Session.send is called with expected timeout
+        args, kwargs = mock_send.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+    def test_no_request_timeout_value_in_config(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        5 times when `request_timeout` does not passed
-        """        
-        config = {'token': '123', "request_timeout": 0}
+        Verify that if request_timeout is not provided in config then default value is used
+        """       
+        config = {'token': '123'}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
-        try:
-            client.request('GET', url)
-        except Timeout as e:
-            pass
+        # Call request method which call requests.Session.send with timeout
+        client.request('GET', url)
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
+        # Verify requests.Session.send is called with expected timeout
+        args, kwargs = mock_send.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
 
 @patch('time.sleep')
-class TestConnectionError(unittest.TestCase):
+@patch('requests.Session.send', side_effect = requests.exceptions.Timeout)
+@patch('requests.Request.prepare')
+class TestRequestTimeoutsBackoff(unittest.TestCase):
     
     endpoint = "forms"
 
-    @patch('requests.Request', side_effect=ConnectionError)
-    def test_connection_error_backoff(self, mocked_request, mock_sleep):
+    def test_connection_error_backoff(self, mocked_request, mock_send, mock_sleep):
         """
-        We mock request.Request method to raise a `ConnectionError` and expect the tap to retry this up to 5 times
+            Verify request function is backoff for 5 times on Timeout exceeption
         """
         config = {'token': '123'}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except ConnectionError as e:
-            pass
+        except requests.exceptions.Timeout as e:
+            # Verify that request.Session.send called 5 times
+            self.assertEqual(mock_send.call_count, 5)
+    
+@patch('time.sleep')
+@patch('requests.Session.send', side_effect = requests.exceptions.ConnectionError)
+@patch('requests.Request.prepare')
+class TestConnectionErrorBackoff(unittest.TestCase):
+    
+    endpoint = "forms"
 
-        # Verify that request.Request called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
- 
+    def test_connection_error_backoff(self, mocked_request, mock_send, mock_sleep):
+        """
+            Verify request function is backoff for 5 times on ConnectionError exceeption
+        """
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except requests.exceptions.ConnectionError as e:
+            # Verify that request.Session.send called 5 times
+            self.assertEqual(mock_send.call_count, 5)
+    

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,132 @@
+import unittest
+from unittest.mock import patch
+
+from requests.exceptions import Timeout
+import tap_typeform.http as client_
+
+REQUEST_TIMEOUT_INT = 300
+REQUEST_TIMEOUT_STR = "300"
+REQUEST_TIMEOUT_FLOAT = 300.05
+
+class TestRequestTimeouts(unittest.TestCase):
+    
+    endpoint = "forms"
+
+    @patch('requests.Request', side_effect=Timeout)
+    def test_request_timeout_backoff_for_string_value_in_config(self, mocked_request):
+        """
+        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
+        3 times when stiring "300" value of `request_timeout` passed
+        """
+        config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_STR}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except Timeout:
+            pass
+
+        # Verify that request.Request called 3 times on Timeout error
+        self.assertEqual(mocked_request.call_count, 3)
+    
+    @patch('requests.Request', side_effect=Timeout)
+    def test_request_timeout_backoff_for_int_value_in_config(self, mocked_request):
+        """
+        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
+        3 times when int 300 value of `request_timeout` passed
+        """
+        config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_INT}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except Timeout:
+            pass
+
+        # Verify that request.Request called 3 times on Timeout error
+        self.assertEqual(mocked_request.call_count, 3)
+        
+    @patch('requests.Request', side_effect=Timeout)
+    def test_request_timeout_backoff_for_float_value_in_config(self, mocked_request):
+        """
+        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
+        3 times when float 300.05 value of `request_timeout` passed
+        """
+        config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_FLOAT}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except Timeout:
+            pass
+
+        # Verify that request.Request called 3 times on Timeout error
+        self.assertEqual(mocked_request.call_count, 3)
+
+    @patch('requests.Request', side_effect=Timeout)
+    def test_request_timeout_backoff_for_empty_string_value_in_config(self, mocked_request):
+        """
+        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
+        3 times when empty string value of `request_timeout` passed
+        """
+        config = {'token': '123', "request_timeout": ""}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except Timeout:
+            pass
+
+        # Verify that request.Request called 3 times on Timeout error
+        self.assertEqual(mocked_request.call_count, 3)
+        
+    @patch('requests.Request', side_effect=Timeout)
+    def test_request_timeout_backoff_for_zero_string_value_in_config(self, mocked_request):
+        """
+        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
+        3 times when zero string value of `request_timeout` passed
+        """
+        config = {'token': '123', "request_timeout": "0"}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except Timeout:
+            pass
+
+        # Verify that request.Request called 3 times on Timeout error
+        self.assertEqual(mocked_request.call_count, 3)
+        
+    @patch('requests.Request', side_effect=Timeout)
+    def test_request_timeout_backoff_for_zero_int_value_in_config(self, mocked_request):
+        """
+        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
+        3 times when int 0 value of `request_timeout` passed
+        """        
+        config = {'token': '123', "request_timeout": 0}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except Timeout:
+            pass
+
+        # Verify that request.Request called 3 times on Timeout error
+        self.assertEqual(mocked_request.call_count, 3)
+        
+    @patch('requests.Request', side_effect=Timeout)
+    def test_request_timeout_backoff_for_none_value_in_config(self, mocked_request):
+        """
+        We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
+        3 times when `request_timeout` does not passed
+        """        
+        config = {'token': '123'}
+        client = client_.Client(config)
+        url = client.build_url(self.endpoint)
+        try:
+            client.request('GET', url)
+        except Timeout:
+            pass
+
+        # Verify that request.Request called 3 times on Timeout error
+        self.assertEqual(mocked_request.call_count, 3)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -8,125 +8,126 @@ REQUEST_TIMEOUT_INT = 300
 REQUEST_TIMEOUT_STR = "300"
 REQUEST_TIMEOUT_FLOAT = 300.05
 
+@patch('time.sleep')
 class TestRequestTimeouts(unittest.TestCase):
     
     endpoint = "forms"
 
     @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_string_value_in_config(self, mocked_request):
+    def test_request_timeout_backoff_for_string_value_in_config(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        3 times when stiring "300" value of `request_timeout` passed
+        5 times when stiring "300" value of `request_timeout` passed
         """
         config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_STR}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout:
+        except Timeout as e:
             pass
 
-        # Verify that request.Request called 3 times on Timeout error
-        self.assertEqual(mocked_request.call_count, 3)
+        # Verify that request.Request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
     
     @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_int_value_in_config(self, mocked_request):
+    def test_request_timeout_backoff_for_int_value_in_config(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        3 times when int 300 value of `request_timeout` passed
+        5 times when int 300 value of `request_timeout` passed
         """
         config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_INT}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout:
+        except Timeout as e:
             pass
 
-        # Verify that request.Request called 3 times on Timeout error
-        self.assertEqual(mocked_request.call_count, 3)
+        # Verify that request.Request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
         
     @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_float_value_in_config(self, mocked_request):
+    def test_request_timeout_backoff_for_float_value_in_config(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        3 times when float 300.05 value of `request_timeout` passed
+        5 times when float 300.05 value of `request_timeout` passed
         """
         config = {'token': '123', "request_timeout": REQUEST_TIMEOUT_FLOAT}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout:
+        except Timeout as e:
             pass
 
-        # Verify that request.Request called 3 times on Timeout error
-        self.assertEqual(mocked_request.call_count, 3)
+        # Verify that request.Request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
 
     @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_empty_string_value_in_config(self, mocked_request):
+    def test_request_timeout_backoff_for_empty_string_value_in_config(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        3 times when empty string value of `request_timeout` passed
+        5 times when empty string value of `request_timeout` passed
         """
         config = {'token': '123', "request_timeout": ""}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout:
+        except Timeout as e:
             pass
 
-        # Verify that request.Request called 3 times on Timeout error
-        self.assertEqual(mocked_request.call_count, 3)
+        # Verify that request.Request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
         
     @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_zero_string_value_in_config(self, mocked_request):
+    def test_request_timeout_backoff_for_zero_string_value_in_config(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        3 times when zero string value of `request_timeout` passed
+        5 times when zero string value of `request_timeout` passed
         """
         config = {'token': '123', "request_timeout": "0"}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout:
+        except Timeout as e:
             pass
 
-        # Verify that request.Request called 3 times on Timeout error
-        self.assertEqual(mocked_request.call_count, 3)
+        # Verify that request.Request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
         
     @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_zero_int_value_in_config(self, mocked_request):
+    def test_request_timeout_backoff_for_zero_int_value_in_config(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        3 times when int 0 value of `request_timeout` passed
+        5 times when int 0 value of `request_timeout` passed
         """        
         config = {'token': '123', "request_timeout": 0}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout:
+        except Timeout as e:
             pass
 
-        # Verify that request.Request called 3 times on Timeout error
-        self.assertEqual(mocked_request.call_count, 3)
+        # Verify that request.Request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
         
     @patch('requests.Request', side_effect=Timeout)
-    def test_request_timeout_backoff_for_none_value_in_config(self, mocked_request):
+    def test_request_timeout_backoff_for_none_value_in_config(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `Timeout` and expect the tap to retry this up to 
-        3 times when `request_timeout` does not passed
+        5 times when `request_timeout` does not passed
         """        
-        config = {'token': '123'}
+        config = {'token': '123', "request_timeout": 0}
         client = client_.Client(config)
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout:
+        except Timeout as e:
             pass
 
-        # Verify that request.Request called 3 times on Timeout error
-        self.assertEqual(mocked_request.call_count, 3)
+        # Verify that request.Request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -137,8 +137,8 @@ class TestConnectionError(unittest.TestCase):
     
     endpoint = "forms"
 
-    @patch('requests.Request', side_effect=Timeout)
-    def test_connection_error_backoff(self, mocked_request, ConnectionError):
+    @patch('requests.Request', side_effect=ConnectionError)
+    def test_connection_error_backoff(self, mocked_request, mock_sleep):
         """
         We mock request.Request method to raise a `ConnectionError` and expect the tap to retry this up to 5 times
         """
@@ -147,7 +147,7 @@ class TestConnectionError(unittest.TestCase):
         url = client.build_url(self.endpoint)
         try:
             client.request('GET', url)
-        except Timeout as e:
+        except ConnectionError as e:
             pass
 
         # Verify that request.Request called 5 times


### PR DESCRIPTION
# Description of change
- Implemented request timeout.
- Added unittest case for the same.
- If config parameter does not pass or pass the value "", "0", 0, "0.0" then set timeout to default value 5min
- Updated the integration test to fix the circleci failure.

# Manual QA steps
 - Set small timeout and verify that sync calls are backing off for timeout error.
- Provide timeout in integer, float, and string format and verify that it's used in the request.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
