### PR TITLE
Bump to v1.4.5, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.5
+  * Fix `landings` stream to be incremental [#58](https://github.com/singer-io/tap-typeform/pull/58)
+
 ## 1.4.4
   * Request TimeOut Implementation [#55](https://github.com/singer-io/tap-typeform/pull/55)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="1.4.4",
+    version="1.4.5",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
This is the version bump for #58 

# Manual QA steps
 - See #58 
 
# Risks
 - See #58 
 
# Rollback steps
 - revert #58 and bump the version
