### PR TITLE
feat(submitted_landings): add tags property

### DIFF
--- a/tap_typeform/schemas/submitted_landings.json
+++ b/tap_typeform/schemas/submitted_landings.json
@@ -34,6 +34,15 @@
     "hidden": {
       "type": ["null", "string"]
     },
+    "tags": {
+      "type": [
+        "array", 
+        "null"
+      ], 
+      "items": { 
+        "type": "string" 
+      } 
+    },
     "_sdc_form_id": {
       "type": ["null", "string"]
     }

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -273,6 +273,7 @@ class SubmittedLandings(IncrementalStream):
         Add additional data and nested fields to top level
         """
         record.update({
+                "tags": record["tags"] if "tags" in record else [],
                 "_sdc_form_id": additional_data["_sdc_form_id"],
                 "user_agent": record["metadata"]["user_agent"],
                 "platform": record["metadata"]["platform"],

--- a/tests/unittests/test_sync_obj.py
+++ b/tests/unittests/test_sync_obj.py
@@ -202,8 +202,9 @@ class TestAddFieldAt1StLevel(unittest.TestCase):
             "platform": "other",
             "referer": "",
             "network_id": "",
-            "browser": "default"
-        }
+            "browser": "default",
+        },
+        "tags": [ "noodle", "weekly" ]
     }
     sub_landings_exp_record = {
         **sub_landings_record,

--- a/tests/unittests/test_sync_obj.py
+++ b/tests/unittests/test_sync_obj.py
@@ -213,6 +213,7 @@ class TestAddFieldAt1StLevel(unittest.TestCase):
         "network_id": "",
         "browser": "default",
         "hidden": "",
+        "tags": [ "noodle", "weekly" ],
         "_sdc_form_id": "form1"
     }
     unsub_landings_record = {


### PR DESCRIPTION
# Description of change
Add the `tags` property to `submitted_landings`.

Tags are used in typeform to categorize responses ([ref](https://www.typeform.com/help/a/working-with-your-responses-the-table-view-360029253732/#h_01G8DAPE0YWKWK2N8R21N7S8MM)) so I think it's useful data for the tap to extract.

# Manual QA steps

Tested using [target-json](https://github.com/dvelardez/target-json) as a target for this tap:
```
tap-typeform --config config.json --catalog catalog.json | ~/.virtualenvs/target-json/bin/target-json
```

You can add tags to some responses following [these steps](https://www.typeform.com/help/a/working-with-your-responses-the-table-view-360029253732/#h_01G8DAPE0YWKWK2N8R21N7S8MM) and then run the tap. The resulting `tags` property will either be an array of strings (e.g `['myTag', 'myOtherTag']`) or an empty array (`[]`) if it has no tags.
 
# Risks
None that I could think of.
 
# Rollback steps
 - revert this branch
