### PR TITLE
fix(submitted_landings): support submitted landings without answers

### DIFF
--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -90,7 +90,7 @@ class Stream:
             child_obj = STREAMS[child]()
             child_bookmark = get_bookmark(state, child_obj.tap_stream_id, form_id, self.replication_keys[0], start_date)
 
-            if child in selected_stream_ids and record[child_obj.replication_keys[0]] >= child_bookmark:
+            if child in selected_stream_ids and record[child_obj.replication_keys[0]] >= child_bookmark and record[self.child_data_key]:
                 child_catalog = get_schema(catalogs, child)
                 for rec in record[self.child_data_key]:
                     child_obj.add_fields_at_1st_level(rec, {**record, "_sdc_form_id": form_id})

--- a/tests/unittests/test_sync_obj.py
+++ b/tests/unittests/test_sync_obj.py
@@ -144,6 +144,25 @@ class TestIncrementalStream(unittest.TestCase):
         # Verify write records is called if the stream is selected
         self.assertEqual(mock_write_records.call_count, call_count)
 
+    @parameterized.expand([(['answers'], 1)])
+    @mock.patch("tap_typeform.streams.write_records")
+    @mock.patch("tap_typeform.streams.Answers.add_fields_at_1st_level")
+    def test_child_sync_null_key(self, selected_streams, call_count, mock_add_field, mock_write_records, mock_add_field2, mock_request):
+        """
+        Test child sync for the scenario:
+            - If the child is selected and the child key is null then `write_records` will not be called
+        """
+        test_stream = SubmittedLandings()
+        test_stream.records_count = {"answers": 0}
+        test_stream.child_data_key = 'answers'
+
+        record = {"landing_id": 1, "submitted_at": "", "answers": None}
+
+        test_stream.sync_child_stream(record, catalogs, {}, selected_streams, "form1", "", "")
+
+        # Verify write records is NOT called if the child key value is null
+        self.assertEqual(mock_write_records.call_count, 0)
+
 
 @mock.patch("tap_typeform.client.Client.request")
 class TestFormsStream(unittest.TestCase):


### PR DESCRIPTION
# Description of change

This fixes a problem in which this tap would fail when at least 1 submitted landing had no answers. This was resulting in a problem in which the process would exit and a bunch of data would not be extracted.

This problem happens for forms in which every field is not required, thus the user is able to submit the response without answering any questions. The following error then would show up when running this tap if at least a single user response fell in such scenario:

```
CRITICAL 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/Users/murilo.kakazu/.virtualenvs/tap-typeform/bin/tap-typeform", line 33, in <module>
    sys.exit(load_entry_point('tap-typeform==2.0.0', 'console_scripts', 'tap-typeform')())
  File "/Users/murilo.kakazu/.virtualenvs/tap-typeform/lib/python3.10/site-packages/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/Users/murilo.kakazu/.virtualenvs/tap-typeform/lib/python3.10/site-packages/tap_typeform-2.0.0-py3.10.egg/tap_typeform/__init__.py", line 49, in main
    _sync(client, config, args.state, catalog.to_dict())
  File "/Users/murilo.kakazu/.virtualenvs/tap-typeform/lib/python3.10/site-packages/tap_typeform-2.0.0-py3.10.egg/tap_typeform/sync.py", line 83, in sync
    stream_obj.sync_obj(client, state, catalog['streams'], form, config["start_date"],
  File "/Users/murilo.kakazu/.virtualenvs/tap-typeform/lib/python3.10/site-packages/tap_typeform-2.0.0-py3.10.egg/tap_typeform/streams.py", line 151, in sync_obj
    max_bookmark = self.write_records(records, catalogs, selected_stream_ids,
  File "/Users/murilo.kakazu/.virtualenvs/tap-typeform/lib/python3.10/site-packages/tap_typeform-2.0.0-py3.10.egg/tap_typeform/streams.py", line 127, in write_records
    max_bookmark =  self.sync_child_stream(record, catalogs, state, selected_stream_ids,form_id, start_date, max_bookmark)
  File "/Users/murilo.kakazu/.virtualenvs/tap-typeform/lib/python3.10/site-packages/tap_typeform-2.0.0-py3.10.egg/tap_typeform/streams.py", line 95, in sync_child_stream
    for rec in record[self.child_data_key]:
TypeError: 'NoneType' object is not iterable
``` 

This is bad, as even if the admin updates the form now making the questions required, the existing responses will still fail to be processed by this tap, as old responses without answers will still exist.

I fixed this by simply checking if the stream's child key is blank on the record, then it won't try to process the children data. e.g: when running the `submitted_landing` stream, if the record's `answers` attribute is blank, then it will register a `submitted_landing`, but no `answers`. As expected 😄

Also, this fixes both reported issues: https://github.com/singer-io/tap-typeform/issues/22 and https://github.com/singer-io/tap-typeform/issues/24

# Manual QA steps

1 - Create a form, with 1 or more questions, in which none of them have the "required" validation. e.g:
<img width="312" alt="image" src="https://user-images.githubusercontent.com/15305591/199115046-514b224d-c69b-41fb-ae88-8c45a3fb80ba.png">
2 - Open the form and submit it without answering the questions
3 - Run this tap for that form_id
4 - 💥! `CRITICAL 'NoneType' object is not iterable`
 
# Risks
 - None I could think of
 
# Rollback steps
 - revert this branch
