### PR TITLE
TDL-21131 - 'NoneType' object is not iterable

### DIFF
--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -90,7 +90,7 @@ class Stream:
             child_obj = STREAMS[child]()
             child_bookmark = get_bookmark(state, child_obj.tap_stream_id, form_id, self.replication_keys[0], start_date)
 
-            if child in selected_stream_ids and record[child_obj.replication_keys[0]] >= child_bookmark:
+            if child in selected_stream_ids and record[child_obj.replication_keys[0]] >= child_bookmark and record[self.child_data_key]:
                 child_catalog = get_schema(catalogs, child)
                 for rec in record[self.child_data_key]:
                     child_obj.add_fields_at_1st_level(rec, {**record, "_sdc_form_id": form_id})
@@ -123,7 +123,7 @@ class IncrementalStream(Stream):
                         self.records_count[self.tap_stream_id] += 1
 
                     # Write selected child records
-                    if self.children and record.get(self.child_data_key):
+                    if self.children and self.child_data_key in record:
                         max_bookmark =  self.sync_child_stream(record, catalogs, state, selected_stream_ids,form_id, start_date, max_bookmark)
 
         return max_bookmark

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -123,7 +123,7 @@ class IncrementalStream(Stream):
                         self.records_count[self.tap_stream_id] += 1
 
                     # Write selected child records
-                    if self.children and self.child_data_key in record:
+                    if self.children and record.get(self.child_data_key):
                         max_bookmark =  self.sync_child_stream(record, catalogs, state, selected_stream_ids,form_id, start_date, max_bookmark)
 
         return max_bookmark

--- a/tests/unittests/test_sync_obj.py
+++ b/tests/unittests/test_sync_obj.py
@@ -106,8 +106,8 @@ class TestIncrementalStream(unittest.TestCase):
         test_stream.records_count = {"submitted_landings": 0}
 
         records = [
-            {"landing_id": 1, "submitted_at": "", "answers": []},
-            {"landing_id": 2, "submitted_at": "", "answers": []},
+            {"landing_id": 1, "submitted_at": "", "answers": [11]},
+            {"landing_id": 2, "submitted_at": "", "answers": [12]},
             {"landing_id": 3, "submitted_at": ""},
         ]
 

--- a/tests/unittests/test_sync_obj.py
+++ b/tests/unittests/test_sync_obj.py
@@ -106,8 +106,8 @@ class TestIncrementalStream(unittest.TestCase):
         test_stream.records_count = {"submitted_landings": 0}
 
         records = [
-            {"landing_id": 1, "submitted_at": "", "answers": [11]},
-            {"landing_id": 2, "submitted_at": "", "answers": [12]},
+            {"landing_id": 1, "submitted_at": "", "answers": []},
+            {"landing_id": 2, "submitted_at": "", "answers": []},
             {"landing_id": 3, "submitted_at": ""},
         ]
 
@@ -143,6 +143,25 @@ class TestIncrementalStream(unittest.TestCase):
 
         # Verify write records is called if the stream is selected
         self.assertEqual(mock_write_records.call_count, call_count)
+
+    @parameterized.expand([(['answers'], 1)])
+    @mock.patch("tap_typeform.streams.write_records")
+    @mock.patch("tap_typeform.streams.Answers.add_fields_at_1st_level")
+    def test_child_sync_null_key(self, selected_streams, call_count, mock_add_field, mock_write_records, mock_add_field2, mock_request):
+        """
+        Test child sync for the scenario:
+            - If the child is selected and the child key is null then `write_records` will not be called
+        """
+        test_stream = SubmittedLandings()
+        test_stream.records_count = {"answers": 0}
+        test_stream.child_data_key = 'answers'
+
+        record = {"landing_id": 1, "submitted_at": "", "answers": None}
+
+        test_stream.sync_child_stream(record, catalogs, {}, selected_streams, "form1", "", "")
+
+        # Verify write records is NOT called if the child key value is null
+        self.assertEqual(mock_write_records.call_count, 0)
 
 
 @mock.patch("tap_typeform.client.Client.request")


### PR DESCRIPTION
# Description of change
This issue occurs when the form response is submitted without answering any of the questions in the form.

- Fixed the issue by checking if the stream's child key is empty in the record if yes then it will not try to process the children's data. 
- Updated the respective unit test case

e.g: When running the `submitted_landing` stream, if the record's answers attribute is empty, then it will register a `submitted_landing`, but no answers are present.

# Manual QA steps
 - Create a form with questions
 - Open the form using the form link
 - Submit the form without answering any of the questions
 - Run the tap with the respective form id (i.e. `forms` field in config.json)
 This will reproduce the **'NoneType' object is not iterable** error
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
