### PR TITLE
TDL 22684/sync all form ids and handle no questions error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+  * Fixes/Handles following [#73](https://github.com/singer-io/tap-typeform/pull/73)
+    * Syncs data for all forms if `forms` field is missing in config and makes the field as optional
+    * Prevents tap from failing when there are no questions associated with a form
+
 ## 2.0.1
   * Adds a condition to check if `submitted_landings` stream's child key is blank [#69](https://github.com/singer-io/tap-typeform/pull/69)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="2.0.1",
+    version="2.1.0",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",

--- a/tap_typeform/__init__.py
+++ b/tap_typeform/__init__.py
@@ -2,11 +2,11 @@
 import singer
 from singer import utils
 from tap_typeform.discover import discover as _discover
-from tap_typeform.sync import _forms_to_list, sync as _sync
+from tap_typeform.sync import sync as _sync
 from tap_typeform.client import Client
 from tap_typeform.streams import Forms
 
-REQUIRED_CONFIG_KEYS = ["start_date", "token", "forms"]
+REQUIRED_CONFIG_KEYS = ["start_date", "token"]
 
 LOGGER = singer.get_logger()
 
@@ -20,11 +20,12 @@ def validate_form_ids(client, config):
     """Validate the form ids passed in the config"""
     form_stream = Forms()
 
+    api_forms = {form.get('id') for res in form_stream.get_forms(client) for form in res if form}
     if not config.get('forms'):
-        raise NoFormsProvidedError("No forms were provided in the config")
+        LOGGER.info("No form ids provided in config, fetching all forms")
+        return api_forms
 
-    config_forms = _forms_to_list(config)
-    api_forms = {form.get('id') for res in form_stream.get_forms(client) for form in res}
+    config_forms = set(map(str.strip, config.get("forms").split(',')))
 
     mismatched_forms = config_forms.difference(api_forms)
 
@@ -32,6 +33,7 @@ def validate_form_ids(client, config):
         # Raise an error if any form-id from config is not matching
         # from ids from API response
         raise FormMistmatchError("FormMistmatchError: forms {} not returned by API".format(mismatched_forms))
+    return config_forms
 
 
 @utils.handle_top_exception(LOGGER)
@@ -39,14 +41,14 @@ def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
     client = Client(config)
-    validate_form_ids(client, config)
+    valid_forms = validate_form_ids(client, config)
     if args.discover:
         catalog = _discover()
         catalog.dump()
     else:
         catalog = args.catalog \
             if args.catalog else _discover()
-        _sync(client, config, args.state, catalog.to_dict())
+        _sync(client, config, args.state, catalog.to_dict(), valid_forms)
 
 if __name__ == "__main__":
     main()

--- a/tap_typeform/__init__.py
+++ b/tap_typeform/__init__.py
@@ -13,8 +13,6 @@ LOGGER = singer.get_logger()
 class FormMistmatchError(Exception):
     pass
 
-class NoFormsProvidedError(Exception):
-    pass
 
 def validate_form_ids(client, config):
     """Validate the form ids passed in the config"""

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import json
 import pendulum
 from datetime import datetime
@@ -173,8 +172,12 @@ class FullTableStream(Stream):
         stream_catalog = get_schema(catalogs, self.tap_stream_id)
         response = client.request(full_url, params=self.params)
 
+        if self.data_key not in response:
+            LOGGER.info('Seems like there are no questions associated with form {}'.format(form_id))
+            return
+
         for record in response[self.data_key]:
-            self.add_fields_at_1st_level(record,{"form_id": form_id})
+            self.add_fields_at_1st_level(record, {"form_id": form_id})
 
         write_records(stream_catalog, self.tap_stream_id, response[self.data_key])
         self.records_count[self.tap_stream_id] += len(response[self.data_key])

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -173,7 +173,7 @@ class FullTableStream(Stream):
         response = client.request(full_url, params=self.params)
 
         if self.data_key not in response:
-            LOGGER.info('Seems like there are no questions associated with form {}'.format(form_id))
+            LOGGER.info('There are no questions associated with form {}'.format(form_id))
             return
 
         for record in response[self.data_key]:

--- a/tap_typeform/sync.py
+++ b/tap_typeform/sync.py
@@ -1,14 +1,7 @@
 import singer
-import pendulum
 from tap_typeform.streams import STREAMS
 
 LOGGER = singer.get_logger()
-
-def _forms_to_list(config, keyword='forms'):
-    """
-    Splits entries into a list and strips out surrounding blank spaces.
-    """
-    return set(map(str.strip, config.get(keyword).split(',')))
 
 
 def write_schemas(stream_id, catalog, selected_streams):
@@ -50,7 +43,7 @@ def get_stream_to_sync(selected_streams):
             streams_to_sync.append(stream_name)
     return streams_to_sync
 
-def sync(client, config, state, catalog):
+def sync(client, config, state, catalog, forms_to_sync):
     """
     Sync selected streams.
     """
@@ -78,7 +71,7 @@ def sync(client, config, state, catalog):
         elif not stream_obj.parent:
             write_schemas(stream, catalog, selected_streams)
 
-            for form in _forms_to_list(config):
+            for form in forms_to_sync:
 
                 stream_obj.sync_obj(client, state, catalog['streams'], form, config["start_date"],
                                     selected_streams, records_count)

--- a/tests/unittests/test_main.py
+++ b/tests/unittests/test_main.py
@@ -98,17 +98,29 @@ class TestValidateFormIds(unittest.TestCase):
             [{'id': 'form1'}, {'id': 'form2'}, {'id': 'form3'}]]
 
         # Verify no exception was raised
-        validate_form_ids(None, config)
+        api_forms = validate_form_ids(None, config)
+
+        # Assertion to test validate_form_ids return only the configured form IDs
+        self.assertEqual(api_forms, {"form1", "form2"})
 
     def test_no_form_given(self, mock_forms):
         """
-        Test when no forms are given in config, an error is raised with an expected message.
+        Test when no forms are given in config, a statement is logged with an expected message.
         """
         config = {}
+        mock_forms.return_value.get_forms.return_value = [
+            [{'id': 'form1'}, {'id': 'form2'}, {'id': 'form3'}]]
         with self.assertLogs(level='INFO') as log_statement:
-            validate_form_ids(None, config)
+            api_forms = validate_form_ids(None, config)
             self.assertEqual(log_statement.output,
                              ['INFO:root:No form ids provided in config, fetching all forms'])
+
+        # Assertion to make sure we call the get_forms function once
+        self.assertEqual(mock_forms.return_value.get_forms.call_count, 1)
+
+        # Assertion to test validate_form_ids returns all the form IDs from API response
+        self.assertEqual(api_forms, {"form1", "form2", "form3"})
+
 
     def test_mismatch_forms(self, mock_forms):
         """

--- a/tests/unittests/test_main.py
+++ b/tests/unittests/test_main.py
@@ -1,18 +1,19 @@
 import unittest
 from unittest import mock
-from tap_typeform import (main, NoFormsProvidedError,
-                            FormMistmatchError, validate_form_ids)
+from tap_typeform import (main,
+                          FormMistmatchError, validate_form_ids)
 from singer.catalog import Catalog
 
 
 class MockArgs:
     """Mock args object class"""
 
-    def __init__(self, config = None, catalog = None, state = {}, discover = False) -> None:
-        self.config = config 
+    def __init__(self, config=None, catalog=None, state={}, discover=False) -> None:
+        self.config = config
         self.catalog = catalog
         self.state = state
         self.discover = discover
+
 
 @mock.patch("tap_typeform.validate_form_ids")
 @mock.patch("singer.utils.parse_args")
@@ -31,23 +32,23 @@ class TestMainWorkflow(unittest.TestCase):
         Test `_discover` function is called for discover mode.
         """
         mock_discover.dump.return_value = dict()
-        mock_args.return_value = MockArgs(discover = True, config = self.mock_config)
+        mock_args.return_value = MockArgs(discover=True, config=self.mock_config)
         main()
 
         self.assertTrue(mock_discover.called)
         self.assertFalse(mock_sync.called)
-
 
     def test_sync_with_catalog(self, mock_sync, mock_discover, mock_args, mock_validate):
         """
         Test sync mode with catalog given in args.
         """
 
-        mock_args.return_value = MockArgs(config=self.mock_config, catalog=Catalog.from_dict(self.mock_catalog))
+        mock_args.return_value = MockArgs(config=self.mock_config,
+                                          catalog=Catalog.from_dict(self.mock_catalog))
         main()
 
         # Verify `_sync` is called with expected arguments
-        mock_sync.assert_called_with(mock.ANY, self.mock_config, {}, self.mock_catalog)
+        mock_sync.assert_called_with(mock.ANY, self.mock_config, {}, self.mock_catalog, mock_validate.return_value)
 
         # verify `_discover` function is not called
         self.assertFalse(mock_discover.called)
@@ -63,7 +64,7 @@ class TestMainWorkflow(unittest.TestCase):
         main()
 
         # Verify `_sync` is called with expected arguments
-        mock_sync.assert_called_with(mock.ANY, self.mock_config, {}, {"schema": "", "metadata": ""})
+        mock_sync.assert_called_with(mock.ANY, self.mock_config, {}, {"schema": "", "metadata": ""}, mock_validate.return_value)
 
         # verify `_discover` function is  called
         self.assertTrue(mock_discover.called)
@@ -73,11 +74,13 @@ class TestMainWorkflow(unittest.TestCase):
         Test sync mode with the state given in args.
         """
         mock_state = {"bookmarks": {"projects": ""}}
-        mock_args.return_value = MockArgs(config=self.mock_config, catalog=Catalog.from_dict(self.mock_catalog), state=mock_state)
+        mock_args.return_value = MockArgs(config=self.mock_config,
+                                          catalog=Catalog.from_dict(self.mock_catalog),
+                                          state=mock_state)
         main()
 
         # Verify `_sync` is called with expected arguments
-        mock_sync.assert_called_with(mock.ANY, self.mock_config, mock_state, self.mock_catalog)
+        mock_sync.assert_called_with(mock.ANY, self.mock_config, mock_state, self.mock_catalog, mock_validate.return_value)
 
 
 @mock.patch("tap_typeform.Forms")
@@ -85,13 +88,14 @@ class TestValidateFormIds(unittest.TestCase):
     """
     Test `validate_form_ids` function.
     """
-    
+
     def test_all_correct_forms(self, mock_forms):
         """
         Test when proper form ids are passed, No error raised.
         """
         config = {"forms": "form1,form2"}
-        mock_forms.return_value.get_forms.return_value = [[{'id': 'form1'}, {'id': 'form2'}, {'id': 'form3'}]]
+        mock_forms.return_value.get_forms.return_value = [
+            [{'id': 'form1'}, {'id': 'form2'}, {'id': 'form3'}]]
 
         # Verify no exception was raised
         validate_form_ids(None, config)
@@ -101,21 +105,22 @@ class TestValidateFormIds(unittest.TestCase):
         Test when no forms are given in config, an error is raised with an expected message.
         """
         config = {}
-        with self.assertRaises(NoFormsProvidedError) as e:
+        with self.assertLogs(level='INFO') as log_statement:
             validate_form_ids(None, config)
+            self.assertEqual(log_statement.output,
+                             ['INFO:root:No form ids provided in config, fetching all forms'])
 
-        # Verify exception raised with expected error message
-        self.assertEqual(str(e.exception), "No forms were provided in the config")
-    
     def test_mismatch_forms(self, mock_forms):
         """
         Test wrong form ids given in config raise MismatchError.
         """
         config = {"forms": "form1,form4"}
-        mock_forms.return_value.get_forms.return_value = [[{'id': 'form1'}, {'id': 'form2'}, {'id': 'form3'}]]
-        
+        mock_forms.return_value.get_forms.return_value = [
+            [{'id': 'form1'}, {'id': 'form2'}, {'id': 'form3'}]]
+
         with self.assertRaises(FormMistmatchError) as e:
             validate_form_ids(None, config)
 
         # Verify exception raised with expected error message
-        self.assertEqual(str(e.exception), "FormMistmatchError: forms {} not returned by API".format({"form4"}))
+        self.assertEqual(str(e.exception),
+                         "FormMistmatchError: forms {} not returned by API".format({"form4"}))


### PR DESCRIPTION
# Description of change
Handles/Fixes:
- Syncs data for all forms if no form ID is provided in config.
- Currently, tap fails with an following error when there are no questions associated with a form. Handles this scenario by logging a statement and continues to sync data for other streams.
- Updates unittests
```
CRITICAL 'fields'
Traceback (most recent call last):
  File "/Users/Documents/project/taps/tap-typeform/tap_typeform/__init__.py", line 54, in <module>
    main()
  File "/Users/Documents/project/taps/tap-typeform/typeform-venv/lib/python3.9/site-packages/singer_python-5.10.0-py3.9.egg/singer/utils.py", line 229, in wrapped
    return fnc(*args, **kwargs)
  File "/Users/Documents/project/taps/tap-typeform/tap_typeform/__init__.py", line 51, in main
    _sync(client, config, args.state, catalog.to_dict(), valid_forms)
  File "/Users/Documents/project/taps/tap-typeform/typeform-venv/lib/python3.9/site-packages/tap_typeform-2.0.1-py3.9.egg/tap_typeform/sync.py", line 76, in sync
    stream_obj.sync_obj(client, state, catalog['streams'], form, config["start_date"],
  File "/Users/Documents/project/taps/tap-typeform/typeform-venv/lib/python3.9/site-packages/tap_typeform-2.0.1-py3.9.egg/tap_typeform/streams.py", line 176, in sync_obj
    for record in response[self.data_key]:
KeyError: 'fields'
```


# Manual QA steps
 - Tested without having `forms` field in config and noticed data being extracted for all the forms.
 - Tested with `forms` field value as `""` and `None`  and noticed data being extracted for all the forms.
 - Tested with single valid `form_id` in config and noticed data being extracted only for that single form id.
 - Tested with multiple valid `form_ids` which are comma separated in config and noticed data being extracted only for those form IDs
 - Created a form with no questions and made sure tap logs a statement which reads `There are no questions associated with form` without failing.
 
# Risks
 - Low, all the existing connections should be having `forms` field configured. This changes will not have any impact on them
 
# Rollback steps
 - revert this branch
