### PR TITLE
Make formId as optional param and sync data for all forms if not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.0
+  * Syncs data for all forms if forms field is missing in config and makes the field as optional [#74](https://github.com/singer-io/tap-typeform/pull/74)
+
 ## 1.4.5
   * Fix `landings` stream to be incremental [#58](https://github.com/singer-io/tap-typeform/pull/58)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="1.4.5",
+    version="1.5.0",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",

--- a/tap_typeform/context.py
+++ b/tap_typeform/context.py
@@ -24,6 +24,7 @@ class Context(object):
         self.now = datetime.utcnow()
         self.stream_map = None
         self.counts = {}
+        self.form_ids = set()
 
     @property
     def catalog(self):

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -339,7 +339,7 @@ def sync_landings(atx, form_id):
 
 
 def sync_forms(atx):
-    for form_id in atx.config.get('forms').split(','):
+    for form_id in atx.form_ids:
         LOGGER.info('form: {} '.format(form_id))
 
         # pull back the form question details


### PR DESCRIPTION
# Description of change
This PR is duplicate of [PR#73](https://github.com/singer-io/tap-typeform/pull/73) but code changes were made with base as tag 1.4.5
Since 80% connections still use 1.latest, this change should be deployed for 1.latest as well

# Manual QA steps
 - Tested without having forms field in config and noticed data being extracted for all the forms.
 - Tested with forms field value as "" and None and noticed data being extracted for all the forms.
 - Tested with single valid form_id in config and noticed data being extracted only for that single form id.
 - Tested with multiple valid form_ids which are comma separated in config and noticed data being extracted only for those form IDs
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
