### PR TITLE
TDL-21114 add tags property for submitted_landings stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+  * Adds `tags` property to `submitted_landings` stream [#75](https://github.com/singer-io/tap-typeform/pull/75)
+
 ## 2.1.0
   * Fixes/Handles following [#73](https://github.com/singer-io/tap-typeform/pull/73)
     * Syncs data for all forms if `forms` field is missing in config and makes the field as optional

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="2.1.0",
+    version="2.2.0",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",

--- a/tap_typeform/schemas/submitted_landings.json
+++ b/tap_typeform/schemas/submitted_landings.json
@@ -34,6 +34,15 @@
     "hidden": {
       "type": ["null", "string"]
     },
+    "tags": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
     "_sdc_form_id": {
       "type": ["null", "string"]
     }

--- a/tap_typeform/schemas/submitted_landings.json
+++ b/tap_typeform/schemas/submitted_landings.json
@@ -35,15 +35,9 @@
       "type": ["null", "string"]
     },
     "tags": {
-      "type": [
-        "null",
-        "array"
-      ],
+      "type": ["null", "array"],
       "items": {
-        "type": [
-          "null",
-          "string"
-        ]
+        "type": ["null", "string"]
       }
     },
     "_sdc_form_id": {

--- a/tap_typeform/schemas/submitted_landings.json
+++ b/tap_typeform/schemas/submitted_landings.json
@@ -36,11 +36,14 @@
     },
     "tags": {
       "type": [
-        "array",
-        "null"
+        "null",
+        "array"
       ],
       "items": {
-        "type": "string"
+        "type": [
+          "null",
+          "string"
+        ]
       }
     },
     "_sdc_form_id": {

--- a/tap_typeform/schemas/submitted_landings.json
+++ b/tap_typeform/schemas/submitted_landings.json
@@ -37,7 +37,7 @@
     "tags": {
       "type": ["null", "array"],
       "items": {
-        "type": ["string"]
+        "type": ["null", "string"]
       }
     },
     "_sdc_form_id": {

--- a/tap_typeform/schemas/submitted_landings.json
+++ b/tap_typeform/schemas/submitted_landings.json
@@ -37,7 +37,7 @@
     "tags": {
       "type": ["null", "array"],
       "items": {
-        "type": ["null", "string"]
+        "type": ["string"]
       }
     },
     "_sdc_form_id": {

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -276,7 +276,7 @@ class SubmittedLandings(IncrementalStream):
         Add additional data and nested fields to top level
         """
         record.update({
-                "tags": record["tags"] if "tags" in record else [],
+                "tags": record.get("tags"),
                 "_sdc_form_id": additional_data["_sdc_form_id"],
                 "user_agent": record["metadata"]["user_agent"],
                 "platform": record["metadata"]["platform"],

--- a/tap_typeform/streams.py
+++ b/tap_typeform/streams.py
@@ -276,6 +276,7 @@ class SubmittedLandings(IncrementalStream):
         Add additional data and nested fields to top level
         """
         record.update({
+                "tags": record["tags"] if "tags" in record else [],
                 "_sdc_form_id": additional_data["_sdc_form_id"],
                 "user_agent": record["metadata"]["user_agent"],
                 "platform": record["metadata"]["platform"],

--- a/tests/unittests/test_sync_obj.py
+++ b/tests/unittests/test_sync_obj.py
@@ -222,7 +222,8 @@ class TestAddFieldAt1StLevel(unittest.TestCase):
             "referer": "",
             "network_id": "",
             "browser": "default"
-        }
+        },
+        "tags": ["noodle", "weekly"]
     }
     sub_landings_exp_record = {
         **sub_landings_record,
@@ -232,7 +233,8 @@ class TestAddFieldAt1StLevel(unittest.TestCase):
         "network_id": "",
         "browser": "default",
         "hidden": "",
-        "_sdc_form_id": "form1"
+        "tags": ["noodle", "weekly"],
+        "_sdc_form_id": "form1",
     }
     unsub_landings_record = {
         "metadata": {


### PR DESCRIPTION
# Description of change
Duplicates #68 

# Manual QA steps
 - Created tags for responses available for different surveys on test account and ran sync to see field being extracted.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
