### PR TITLE
Add token chaining in integration tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -47,6 +47,7 @@ class TypeformBaseTest(unittest.TestCase):
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
         return_value = {
+            'client_id': os.getenv('TAP_TYPEFORM_CLIENT_ID'),
             'start_date' : '2021-05-10T00:00:00Z',
             'forms': os.getenv('TAP_TYPEFORM_FORMS'),
             'incremental_range': 'daily',
@@ -64,7 +65,19 @@ class TypeformBaseTest(unittest.TestCase):
     @staticmethod
     def get_credentials():
         """Authentication information for the test account"""
-        return {'token': os.getenv('TAP_TYPEFORM_TOKEN')}
+        return {
+            'refresh_token': os.getenv('TAP_TYPEFORM_REFRESH_TOKEN'),
+            'token': os.getenv('TAP_TYPEFORM_TOKEN'),
+            'client_secret': os.getenv('TAP_TYPEFORM_CLIENT_SECRET')}
+
+    @staticmethod
+    def preserve_refresh_token(existing_conns, payload):
+        """This method is used get the refresh token from an existing refresh token"""
+        if not existing_conns:
+            return payload
+        conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
+        payload['properties']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
+        return payload
 
     def expected_metadata(self):
         """The expected streams and metadata about the streams"""

--- a/tests/base.py
+++ b/tests/base.py
@@ -76,7 +76,7 @@ class TypeformBaseTest(unittest.TestCase):
         if not existing_conns:
             return payload
         conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
-        payload['properties']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
+        payload['properties']['refresh_token'] = conn_with_creds['credentials'].get('refresh_token')
         return payload
 
     def expected_metadata(self):

--- a/tests/test_typeform_all_fields.py
+++ b/tests/test_typeform_all_fields.py
@@ -17,7 +17,7 @@ class TypeformAllFieldsTest(TypeformBaseTest):
     """Ensure running the tap with all streams and fields selected results in the replication of all fields."""
 
     def name(self):
-        return "tap_tester_typeform_all_fields_test"
+        return "tap_tester_typeform_using_shared_token_chaining"
 
     def test_run(self):
         """
@@ -29,7 +29,7 @@ class TypeformAllFieldsTest(TypeformBaseTest):
         # Streams to verify all fields tests
         streams_to_test = self.expected_streams()
 
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self, payload_hook=self.preserve_refresh_token)
 
         expected_automatic_fields = self.expected_automatic_fields()
 

--- a/tests/test_typeform_automatic_fields.py
+++ b/tests/test_typeform_automatic_fields.py
@@ -13,7 +13,7 @@ class TypeformAutomaticFields(TypeformBaseTest):
 
     @staticmethod
     def name():
-        return "tap_tester_typeform_automatic_fields"
+        return "tap_tester_typeform_using_shared_token_chaining"
 
     def test_run(self):
         """
@@ -32,7 +32,7 @@ class TypeformAutomaticFields(TypeformBaseTest):
         expected_streams = self.expected_streams()
 
         # Instantiate connection
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self, payload_hook=self.preserve_refresh_token)
 
         # Run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_typeform_bookmarks.py
+++ b/tests/test_typeform_bookmarks.py
@@ -12,7 +12,7 @@ class TypeformBookmarks(TypeformBaseTest):
 
     @staticmethod
     def name():
-        return "tap_tester_typeform_bookmarks"
+        return "tap_tester_typeform_using_shared_token_chaining"
 
     @staticmethod
     def convert_state_to_utc(date_str):
@@ -39,7 +39,7 @@ class TypeformBookmarks(TypeformBaseTest):
         self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=3)
 
         self.start_date = self.start_date_1
-        conn_id = connections.ensure_connection(self, original_properties=False)
+        conn_id = connections.ensure_connection(self, original_properties=False, payload_hook=self.preserve_refresh_token)
 
         # Run in check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)
@@ -72,7 +72,7 @@ class TypeformBookmarks(TypeformBaseTest):
         }
         for stream, new_state in simulated_states.items():
             new_states['bookmarks'][stream] = new_state
-        conn_id_2 = connections.ensure_connection(self, original_properties=False)
+        conn_id_2 = connections.ensure_connection(self, original_properties=False, payload_hook=self.preserve_refresh_token)
         menagerie.set_state(conn_id_2, new_states)
 
         for stream in simulated_states.keys():

--- a/tests/test_typeform_discovery.py
+++ b/tests/test_typeform_discovery.py
@@ -11,7 +11,7 @@ class DiscoveryTest(TypeformBaseTest):
 
     @staticmethod
     def name():
-        return "tap_tester_typeform_discovery_test"
+        return "tap_tester_typeform_using_shared_token_chaining"
 
     def test_run(self):
         """
@@ -32,7 +32,7 @@ class DiscoveryTest(TypeformBaseTest):
         """
         streams_to_test = self.expected_streams()
 
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self, payload_hook=self.preserve_refresh_token)
 
         # Verify that there are catalogs found
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_typeform_pagination.py
+++ b/tests/test_typeform_pagination.py
@@ -11,11 +11,12 @@ class TypeformPaginationTest(TypeformBaseTest):
     """
 
     def name(self):
-        return "tap_tester_typeform_pagination_test"
+        return "tap_tester_typeform_using_shared_token_chaining"
 
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""
         return_value = {
+            'client_id': os.getenv('TAP_TYPEFORM_CLIENT_ID'),
             'start_date' : '2021-05-10T00:00:00Z',
             'forms': os.getenv('TAP_TYPEFORM_FORMS'),
             'incremental_range': 'daily',
@@ -44,7 +45,7 @@ class TypeformPaginationTest(TypeformBaseTest):
     
         self.PAGE_SIZE = page_size
 
-        conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self, payload_hook=self.preserve_refresh_token)
 
         # Verify that there are catalogs found
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_typeform_start_date.py
+++ b/tests/test_typeform_start_date.py
@@ -12,7 +12,7 @@ class TypeformStartDateTest(TypeformBaseTest):
     
     @staticmethod
     def name():
-        return "tap_tester_typeform_start_date_test"
+        return "tap_tester_typeform_using_shared_token_chaining"
 
     start_date_1 = ""
     start_date_2 = ""
@@ -39,7 +39,7 @@ class TypeformStartDateTest(TypeformBaseTest):
         ##########################################################################
 
         # Instantiate connection
-        conn_id_1 = connections.ensure_connection(self)
+        conn_id_1 = connections.ensure_connection(self, payload_hook=self.preserve_refresh_token)
 
         # Run check mode
         found_catalogs_1 = self.run_and_verify_check_mode(conn_id_1)
@@ -65,7 +65,7 @@ class TypeformStartDateTest(TypeformBaseTest):
         ##########################################################################
 
         # Create a new connection with the new start_date
-        conn_id_2 = connections.ensure_connection(self, original_properties=False)
+        conn_id_2 = connections.ensure_connection(self, original_properties=False, payload_hook=self.preserve_refresh_token)
 
         # Run check mode
         found_catalogs_2 = self.run_and_verify_check_mode(conn_id_2)


### PR DESCRIPTION
# Description of change
Add token chaining in `tap-typeform` integration tests.

# Additional dependencies

- Connections-service [PR #1833](https://github.com/stitchdata/connections-service/pull/1833)
- Environment [PR #881](https://github.com/stitchdata/environments/pull/881) needs to be merged to pass the circle ci.

# Manual QA steps
 - On local env, add refresh token and client details
 - Verify token chain work as expected and all integration tests run successfully
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
