### PR TITLE
remove deprecated ratelimit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.2
+  * Remove ratelimit dependency [#83](https://github.com/singer-io/tap-typeform/pull/83)
+
 ## 2.4.1
   * Pin dependencies [#82](https://github.com/singer-io/tap-typeform/pull/82)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="2.4.1",
+    version="2.4.2",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         "singer-python==6.0.0",
         "pendulum==3.0.0",
-        "ratelimit==2.2.1",
         "backoff==2.2.1",
         "requests==2.32.3",
     ],


### PR DESCRIPTION
# Description of change
Removes `ratelimit` library which is deprecated and unused in the tap

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
