### PR TITLE
Bump pendulum from 3.0.0 to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.4.4
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 # Changelog
 
 ## 2.4.3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     install_requires=[
         "singer-python==6.0.1",
-        "pendulum==3.0.0",
+        "pendulum==3.1.0",
         "backoff==2.2.1",
         "requests==2.32.4",
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-typeform",
-    version="2.4.3",
+    version="2.4.4",
     description="Singer.io tap for extracting data from the TypeForm Responses API",
     author="bytcode.io",
     url="http://singer.io",
@@ -13,7 +13,7 @@ setup(
         "singer-python==6.0.1",
         "pendulum==3.1.0",
         "backoff==2.2.1",
-        "requests==2.32.4",
+        "requests==2.33.0",
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Bump to a newer patch version for compatibility.